### PR TITLE
screensaver

### DIFF
--- a/Display.h
+++ b/Display.h
@@ -129,6 +129,8 @@ uint8_t disp_ext_fb = false;
 unsigned char fb[512];
 uint32_t last_disp_update = 0;
 int disp_update_interval = 1000/disp_target_fps;
+uint32_t last_screensaver = 0;
+uint32_t screensaver_interval = 600000;
 uint32_t last_page_flip = 0;
 uint32_t last_interface_page_flip = 0;
 int page_interval = 4000;
@@ -1111,6 +1113,12 @@ void update_display(bool blank = false) {
       update_stat_area();
       update_disp_area();
       display.display();
+      if (millis()-last_screensaver >= screensaver_interval) {
+        display.invertDisplay(1);
+        delay(500);
+        display.invertDisplay(0);
+        last_screensaver = millis();
+      }
       #elif DISP_H == 122 && (DISPLAY == EINK_BW || DISPLAY == EINK_3C)
       display.setFullWindow();
       display.fillScreen(GxEPD_WHITE);


### PR DESCRIPTION
Adds a rudimentary screen saver that briefly (500ms) inverts the screen every 10 minutes on OLED displays to prevent burn-in.