### PR TITLE
small make prep fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ clean:
 	-rm -r ./build
 	-rm ./Release/rnode_firmware*
 
-prep: prep-esp32 prep-samd
+prep: prep-esp32 prep-nrf prep-samd
 
 prep-esp32:
 	arduino-cli core update-index --config-file arduino-cli.yaml

--- a/arduino-cli.yaml
+++ b/arduino-cli.yaml
@@ -1,5 +1,6 @@
 board_manager:
   additional_urls:
+  - https://adafruit.github.io/arduino-board-index/package_adafruit_index.json
   - https://liberatedsystems.co.uk/rnode-firmware-ce/esp-custom-package.json
   - https://raw.githubusercontent.com/RAKwireless/RAKwireless-Arduino-BSP-Index/main/package_rakwireless_index.json
   - http://unsigned.io/arduino/package_unsignedio_UnsignedBoards_index.json


### PR DESCRIPTION
fixes adds missing adafruit repo used for prep-nrf, and adds prep-nrf to the make prep