### PR TITLE
Start preparing some automation helpers, update building docs a bit

### DIFF
--- a/Boards.h
+++ b/Boards.h
@@ -1120,7 +1120,7 @@
       #define EEPROM_OFFSET EEPROM_SIZE-EEPROM_RESERVED
       #define HAS_EEPROM false
       #define HAS_SD false
-      #define HAS_DISPLAY true
+      #define HAS_DISPLAY false //Temporarially disable display code to not burn out the e-ink until the display code is fixed 
       #define DISPLAY EINK_BW
       #define DISPLAY_MODEL GxEPD2_154_D67
       #define BLE_MANUFACTURER "LilyGO"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,20 @@
+ARG FROM=ubuntu:latest
+FROM ${FROM}
+ENV PATH="~/.local/bin:${PATH}"
+RUN apt update && \
+  DEBIAN_FRONTEND=noninteractive apt --yes upgrade && \
+  DEBIAN_FRONTEND=noninteractive apt --yes install bzip2 curl git make python3 python3-pip && \
+  rm -rf /var/lib/apt/lists/* && \
+  update-alternatives --install /usr/bin/python python /usr/bin/python3 1 && \
+  curl -fsSL https://raw.githubusercontent.com/arduino/arduino-cli/master/install.sh | BINDIR=/usr/local/bin sh
+
+# How to build/run this container (should also work with docker CLI):
+#   nerdctl build --file Dockerfile --tag rnode-builder:latest .
+#   nerdctl run --interactive \
+#     --mount src=${PWD},target=/RNode_Firmware_CE,type=bind \
+#     --mount src=${HOME},target=/root,type=bind \
+#     --tty --rm rnode-builder:latest
+
+# Arduino expects the same name of the directory inside the container as it is
+# named outside, e.g.:  "RNode_Firmware_CE".
+#   See https://github.com/microsoft/vscode-arduino/issues/1665#issuecomment-1764234405

--- a/Documentation/BUILDING.md
+++ b/Documentation/BUILDING.md
@@ -14,6 +14,7 @@ Firstly, figure out which MCU platform your supported board is based on. The tab
 | LilyGO LoRa32 v2.1 |  [Buy here](https://www.lilygo.cc/products/lora3) | SX1276/8 | ESP32 | With and without TCXO |
 | Heltec LoRa32 v2 | No link | SX1276/8 | ESP32 | Discontinued? |
 | Heltec LoRa32 v3 | [Buy here](https://heltec.org/project/wifi-lora-32-v3/) | SX1262 | ESP32 | 
+| Heltec T114 v2.0 | [Buy here](https://heltec.org/project/mesh-node-t114/) | SX1262 | ESP32 |
 | Homebrew ESP32 boards | | Any supported | ESP32 | This can be any board with an Adafruit Feather (or generic) ESP32 chip |
 
 ### ESP32
@@ -35,6 +36,7 @@ Next, you need to find the name of the target for your board. Please reference t
 | LilyGO LoRa32 v2.1 | `lora32_v21` |
 | Heltec LoRa32 v2 | `heltec32_v2` |
 | Heltec LoRa32 v3 | `heltec32_v3` | 
+| Heltec T114 v2.0 | `heltec_t114` or `heltec_t114_gps` |
 | Homebrew ESP32 boards | `genericesp32` |
 
 After you've ascertained the target for the board simply run the following to compile for the board:

--- a/Makefile
+++ b/Makefile
@@ -153,6 +153,7 @@ firmware-opencom-xl:
 	arduino-cli compile --fqbn rakwireless:nrf52:WisCoreRAK4631Board $(COMMON_BUILD_FLAGS) --build-property "compiler.cpp.extra_flags=\"-DBOARD_MODEL=0x52\" \"-DBOARD_VARIANT=0x21\""
 
 firmware-heltec_t114:
+	python3 ./Scripts/heltec_nrf52_bsp_prep.py
 	arduino-cli compile --log --fqbn Heltec_nRF52:Heltec_nRF52:HT-n5262 -e --build-property "build.partitions=no_ota" --build-property "upload.maximum_size=2097152" --build-property "compiler.cpp.extra_flags=\"-DBOARD_MODEL=0x3C\""
 
 firmware-heltec_t114_gps:

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ You must have at least version `2.1.3` of `rnodeconf` installed to update your R
 | Heltec LoRa32 v3 | [Buy here](https://heltec.org/project/wifi-lora-32-v3/) | SX1262 | ESP32 | 
 | LilyGo T3S3 v1.0 | [Buy here](https://lilygo.cc/products/t3s3-v1-0) | SX1262 or SX1276 or SX1280 | ESP32-S3 |
 | LilyGo T-Echo | [Buy here](https://lilygo.cc/products/t-echo-lilygo) | SX1262 | nRF52 |
-| Heltec T114 | [Buy here](https://heltec.org/project/mesh-node-t114/) | SX1262 | nRF52 | 
+| Heltec T114 v2.0 | [Buy here](https://heltec.org/project/mesh-node-t114/) | SX1262 | nRF52 |
 | Homebrew ESP32 boards | | Any supported | ESP32 | This can be any board with an Adafruit Feather (or generic) ESP32 chip |
 
 It's easy to create your own RNodes from one of the supported development boards and devices. If a device or board you want to use is not yet supported, you are welcome to [join the effort](Documentation/CONTRIBUTING.md) and help create a board definition and pin mapping for it!

--- a/Scripts/heltec_nrf52_bsp_prep.py
+++ b/Scripts/heltec_nrf52_bsp_prep.py
@@ -1,0 +1,53 @@
+#!/usr/bin/env python
+
+# This is a helper script to perform some additional preparation steps before
+# building.  This helper script may be deleted once some upstream bugs go away.
+# Tested with Python 3.13.2 on Linux.
+#   See https://github.com/liberatedsystems/RNode_Firmware_CE/blob/master/Documentation/BUILDING.md
+
+# There's a minor issue when building images for "Heltec T114" boards.  The fix
+# has been merged but there's no release after "1.7.0" containing this yet.  As
+# a result, we need to correct some files between the "make prep-nrf" and "make
+# firmware-heltec_t114_gps" steps.
+#   See https://github.com/HelTecAutomation/Heltec_nRF52/issues/4
+#   See https://github.com/HelTecAutomation/Heltec_nRF52/pull/3
+
+# An equivalent shell command for doing this would be the following (GNU sed, not BSD sed):
+#   find ~/.arduino15/packages/Heltec_nRF52 -name 'platform.txt' | xargs \
+#     sed -i 's/recipe\.objcopy\.uf2\.pattern="{tools\.uf2conv\.cmd}"/recipe\.objcopy\.uf2\.pattern={tools\.uf2conv\.cmd}/'
+
+
+from fnmatch import fnmatch
+from os import environ, path, walk
+from re import sub
+from shutil import move
+from tempfile import mkstemp
+
+
+def find_all_files_to_fix() -> list:
+    found = []
+    for root, dirs, files in walk(
+        f'{environ["HOME"]}/.arduino15/packages/Heltec_nRF52'
+    ):
+        for file in files:
+            if fnmatch(file, 'platform.txt'):
+                found.append(path.join(root, file))
+    return found
+
+
+def sed_fix_files_in_place(files: list = []) -> None:
+    for file in files:
+        fd, temp = mkstemp()
+        with open(file, 'r') as source, open(temp, 'w') as dest:
+            for line in source:
+                out = sub(
+                    r'recipe.objcopy.uf2.pattern="{tools.uf2conv.cmd}"',
+                    r'recipe.objcopy.uf2.pattern={tools.uf2conv.cmd}',
+                    line,
+                )
+                dest.write(out)
+        move(temp, file)
+
+
+if '__main__' == __name__:
+    sed_fix_files_in_place(find_all_files_to_fix())


### PR DESCRIPTION
The `Dockerfile` is intended to try to give folks another option for their local build environment.  There is a chance this work will also aid in future attempts to get GitHub actions going for automating release building too.

The `nrf52_post_prep.py` helper Python script is intended to be called from the Makefile `make prep-nrf` target.  However, I would appreciate some help testing this on non-Linux targets first before I call this on every build.  It is needed because there isn't yet a new release of the Heltec_nRF52 dev env (https://github.com/HelTecAutomation/Heltec_nRF52/issues/4).