### PR TITLE
Fix TCX0 and fix SPI default being set incorrectly

### DIFF
--- a/Boards.h
+++ b/Boards.h
@@ -1010,7 +1010,7 @@
       const bool interface_cfg[INTERFACE_COUNT][3] = { 
                     // SX1262
           {
-              true, // DEFAULT_SPI
+              false, // DEFAULT_SPI
               true, // HAS_TCXO
               true  // DIO2_AS_RF_SWITCH
           }, 

--- a/Radio.cpp
+++ b/Radio.cpp
@@ -711,6 +711,8 @@ void sx126x::enableTCXO() {
       uint8_t buf[4] = {MODE_TCXO_1_8V_6X, 0x00, 0x00, 0xFF};
     #elif BOARD_MODEL == BOARD_HELTEC_T114
       uint8_t buf[4] = {MODE_TCXO_1_8V_6X, 0x00, 0x00, 0xFF};
+    #elif BOARD_MODEL == BOARD_E22_ESP32
+      uint8_t buf[4] = {MODE_TCXO_1_8V_6X, 0x00, 0x00, 0xFF};
     #else
       uint8_t buf[4] = {0};
     #endif


### PR DESCRIPTION
Fix E22_ESP32 board incorrect settings

TCX0 voltage set per datasheet to 1.8v https://www.cdebyte.com/pdf-down.aspx?id=1513

DEFAULT_SPI was incorrectly set to true and should be false

DIO2 as RF switch is correct but diagram is incorrect, will make update to documentation shortly as part of this pull-req
