### PR TITLE
Add support for Heltec Wireless Stick Lite v3

### DIFF
--- a/Boards.h
+++ b/Boards.h
@@ -92,7 +92,12 @@
   #define BOARD_HELTEC32_V3   0x3A
   #define MODEL_C5            0xC5 // Heltec Lora32 v3, 433 MHz
   #define MODEL_CA            0xCA // Heltec Lora32 v3, 868 MHz
-  
+
+  #define PRODUCT_HELTEC_WSL_V3 0xCC // Heltec Wireless Stick Lite v3
+  #define BOARD_HELTEC_WSL_V3   0xCD
+  #define MODEL_CE            0xCE // Heltec WSL v3, 433 MHz
+  #define MODEL_CF            0xCF // Heltec WSL v3, 868 MHz
+
   #define PRODUCT_H_W_PAPER   0xC3
   #define BOARD_H_W_PAPER     0x3F
   #define MODEL_C8            0xC8
@@ -189,15 +194,15 @@
       const int pin_led_rx = 14;
       const int pin_led_tx = 32;
       const uint8_t interfaces[INTERFACE_COUNT] = {SX1276};
-      const bool interface_cfg[INTERFACE_COUNT][3] = { 
+      const bool interface_cfg[INTERFACE_COUNT][3] = {
                     // SX127X
           {
               true, // DEFAULT_SPI
               false, // HAS_TCXO
               false  // DIO2_AS_RF_SWITCH
-          }, 
+          },
       };
-      const int8_t interface_pins[INTERFACE_COUNT][10] = { 
+      const int8_t interface_pins[INTERFACE_COUNT][10] = {
                   // SX127X
           {
               4, // pin_ss
@@ -232,15 +237,15 @@
 
       #if BOARD_VARIANT == MODEL_E4 || BOARD_VARIANT == MODEL_E9
       const uint8_t interfaces[INTERFACE_COUNT] = {SX1276};
-      const bool interface_cfg[INTERFACE_COUNT][3] = { 
+      const bool interface_cfg[INTERFACE_COUNT][3] = {
                     // SX127X
           {
               true, // DEFAULT_SPI
               false, // HAS_TCXO
               false  // DIO2_AS_RF_SWITCH
-          }, 
+          },
       };
-      const int8_t interface_pins[INTERFACE_COUNT][10] = { 
+      const int8_t interface_pins[INTERFACE_COUNT][10] = {
                   // SX127X
           {
               18, // pin_ss
@@ -259,15 +264,15 @@
       #elif BOARD_VARIANT == MODEL_E3 || BOARD_VARIANT == MODEL_E8
       #define OCP_TUNED 0x38
       const uint8_t interfaces[INTERFACE_COUNT] = {SX1262};
-      const bool interface_cfg[INTERFACE_COUNT][3] = { 
+      const bool interface_cfg[INTERFACE_COUNT][3] = {
                     // SX1262
           {
               true, // DEFAULT_SPI
               true, // HAS_TCXO
               true  // DIO2_AS_RF_SWITCH
-          }, 
+          },
       };
-      const int8_t interface_pins[INTERFACE_COUNT][10] = { 
+      const int8_t interface_pins[INTERFACE_COUNT][10] = {
                   // SX1262
           {
               18, // pin_ss
@@ -293,15 +298,15 @@
       const int pin_led_tx = 32;
 
       const uint8_t interfaces[INTERFACE_COUNT] = {SX1276};
-      const bool interface_cfg[INTERFACE_COUNT][3] = { 
+      const bool interface_cfg[INTERFACE_COUNT][3] = {
                     // SX127X
           {
               true, // DEFAULT_SPI
               false, // HAS_TCXO
               false  // DIO2_AS_RF_SWITCH
-          }, 
+          },
       };
-      const int8_t interface_pins[INTERFACE_COUNT][10] = { 
+      const int8_t interface_pins[INTERFACE_COUNT][10] = {
                   // SX127X
           {
                4, // pin_ss
@@ -336,15 +341,15 @@
       #endif
 
       const uint8_t interfaces[INTERFACE_COUNT] = {SX1276};
-      const bool interface_cfg[INTERFACE_COUNT][3] = { 
+      const bool interface_cfg[INTERFACE_COUNT][3] = {
                     // SX1276
           {
               true, // DEFAULT_SPI
               false, // HAS_TCXO
               false  // DIO2_AS_RF_SWITCH
-          }, 
+          },
       };
-      const int8_t interface_pins[INTERFACE_COUNT][10] = { 
+      const int8_t interface_pins[INTERFACE_COUNT][10] = {
                   // SX1276
           {
               18, // pin_ss
@@ -380,15 +385,15 @@
 
 
       const uint8_t interfaces[INTERFACE_COUNT] = {SX1276};
-      const bool interface_cfg[INTERFACE_COUNT][3] = { 
+      const bool interface_cfg[INTERFACE_COUNT][3] = {
                     // SX127X
           {
               true, // DEFAULT_SPI
               false, // HAS_TCXO
               false  // DIO2_AS_RF_SWITCH
-          }, 
+          },
       };
-      const int8_t interface_pins[INTERFACE_COUNT][10] = { 
+      const int8_t interface_pins[INTERFACE_COUNT][10] = {
                   // SX127X
           {
               18, // pin_ss
@@ -413,20 +418,20 @@
       #define HAS_CONSOLE true
       #define HAS_EEPROM true
       #define INTERFACE_COUNT 1
-      
+
       const int pin_np = 12;
 
       const uint8_t interfaces[INTERFACE_COUNT] = {SX1276};
       #if HAS_TCXO == true
-        const bool interface_cfg[INTERFACE_COUNT][3] = { 
+        const bool interface_cfg[INTERFACE_COUNT][3] = {
                         // SX127X
               {
                   true, // DEFAULT_SPI
                   true, // HAS_TCXO
                   false  // DIO2_AS_RF_SWITCH
-              }, 
+              },
         };
-      const int8_t interface_pins[INTERFACE_COUNT][10] = { 
+      const int8_t interface_pins[INTERFACE_COUNT][10] = {
                   // SX127X
           {
               18, // pin_ss
@@ -451,16 +456,16 @@
       #endif
 
       #if HAS_TCXO == false
-      const bool interface_cfg[INTERFACE_COUNT][3] = { 
+      const bool interface_cfg[INTERFACE_COUNT][3] = {
                     // SX127X
           {
               true, // DEFAULT_SPI
               false, // HAS_TCXO
               false  // DIO2_AS_RF_SWITCH
-          }, 
+          },
       };
 
-      const int8_t interface_pins[INTERFACE_COUNT][10] = { 
+      const int8_t interface_pins[INTERFACE_COUNT][10] = {
                   // SX127X
           {
               18, // pin_ss
@@ -500,15 +505,15 @@
       #endif
 
       const uint8_t interfaces[INTERFACE_COUNT] = {SX1276};
-      const bool interface_cfg[INTERFACE_COUNT][3] = { 
+      const bool interface_cfg[INTERFACE_COUNT][3] = {
                     // SX127X
           {
               true, // DEFAULT_SPI
               false, // HAS_TCXO
               false  // DIO2_AS_RF_SWITCH
-          }, 
+          },
       };
-      const int8_t interface_pins[INTERFACE_COUNT][10] = { 
+      const int8_t interface_pins[INTERFACE_COUNT][10] = {
                   // SX127X
           {
               18, // pin_ss
@@ -551,15 +556,60 @@
       #endif
 
       const uint8_t interfaces[INTERFACE_COUNT] = {SX1262};
-      const bool interface_cfg[INTERFACE_COUNT][3] = { 
+      const bool interface_cfg[INTERFACE_COUNT][3] = {
                     // SX1262
           {
               true, // DEFAULT_SPI
               true, // HAS_TCXO
               true  // DIO2_AS_RF_SWITCH
-          }, 
+          },
       };
-      const int8_t interface_pins[INTERFACE_COUNT][10] = { 
+      const int8_t interface_pins[INTERFACE_COUNT][10] = {
+                  // SX1262
+          {
+              8, // pin_ss
+              9, // pin_sclk
+              10, // pin_mosi
+              11, // pin_miso
+              13, // pin_busy
+              14, // pin_dio
+              12, // pin_reset
+              -1, // pin_txen
+              -1, // pin_rxen
+              -1  // pin_tcxo_enable
+          }
+      };
+
+    #elif BOARD_MODEL == BOARD_HELTEC_WSL_V3
+      #define IS_ESP32S3 true
+      #define HAS_DISPLAY false
+      #define HAS_BLUETOOTH false
+      #define HAS_BLE true
+      #define HAS_PMU true
+      #define HAS_CONSOLE true
+      #define HAS_EEPROM true
+      #define HAS_INPUT true
+      #define HAS_SLEEP true
+      #define PIN_WAKEUP GPIO_NUM_0
+      #define WAKEUP_LEVEL 0
+      #define INTERFACE_COUNT 1
+      #define OCP_TUNED 0x38
+
+      const int pin_btn_usr1 = 0;
+
+      const int pin_led_rx = 35;
+      const int pin_led_tx = 35;
+
+      const uint8_t interfaces[INTERFACE_COUNT] = {SX1262};
+      const bool interface_cfg[INTERFACE_COUNT][3] = {
+                    // SX1262
+          {
+              true, // DEFAULT_SPI
+              true, // HAS_TCXO
+              true  // DIO2_AS_RF_SWITCH
+          },
+      };
+      const int8_t interface_pins[INTERFACE_COUNT][10] = {
                   // SX1262
           {
               8, // pin_ss
@@ -607,15 +657,15 @@
       #endif
 
       const uint8_t interfaces[INTERFACE_COUNT] = {SX1262};
-      const bool interface_cfg[INTERFACE_COUNT][3] = { 
+      const bool interface_cfg[INTERFACE_COUNT][3] = {
                     // SX1262
           {
               true, // DEFAULT_SPI
               true, // HAS_TCXO
               true  // DIO2_AS_RF_SWITCH
-          }, 
+          },
       };
-      const int8_t interface_pins[INTERFACE_COUNT][10] = { 
+      const int8_t interface_pins[INTERFACE_COUNT][10] = {
                   // SX1262
           {
               8, // pin_ss
@@ -661,15 +711,15 @@
 
 
       const uint8_t interfaces[INTERFACE_COUNT] = {SX1276};
-      const bool interface_cfg[INTERFACE_COUNT][3] = { 
+      const bool interface_cfg[INTERFACE_COUNT][3] = {
                     // SX1276
           {
               false, // DEFAULT_SPI
               true, // HAS_TCXO
               true  // DIO2_AS_RF_SWITCH
-          }, 
+          },
       };
-      const uint8_t interface_pins[INTERFACE_COUNT][10] = { 
+      const uint8_t interface_pins[INTERFACE_COUNT][10] = {
                   // SX1276
           {
               8, // pin_ss
@@ -713,15 +763,15 @@
       #endif
 
       const uint8_t interfaces[INTERFACE_COUNT] = {SX1276};
-      const bool interface_cfg[INTERFACE_COUNT][3] = { 
+      const bool interface_cfg[INTERFACE_COUNT][3] = {
                     // SX127X
           {
               true, // DEFAULT_SPI
               false, // HAS_TCXO
               false  // DIO2_AS_RF_SWITCH
-          }, 
+          },
       };
-      const uint8_t interface_pins[INTERFACE_COUNT][10] = { 
+      const uint8_t interface_pins[INTERFACE_COUNT][10] = {
                   // SX127X
           {
               18, // pin_ss
@@ -736,7 +786,7 @@
               -1  // pin_tcxo_enable
           }
       };
-   
+
     #elif BOARD_MODEL == BOARD_T3S3
       #define IS_ESP32S3 true
       #define HAS_DISPLAY true
@@ -759,15 +809,15 @@
 
       #if BOARD_VARIANT == MODEL_A1 || BOARD_VARIANT == MODEL_A6
       const uint8_t interfaces[INTERFACE_COUNT] = {SX1262};
-      const bool interface_cfg[INTERFACE_COUNT][3] = { 
+      const bool interface_cfg[INTERFACE_COUNT][3] = {
                     // SX1262
           {
               false, // DEFAULT_SPI
               true, // HAS_TCXO
               true  // DIO2_AS_RF_SWITCH
-          }, 
+          },
       };
-      const uint8_t interface_pins[INTERFACE_COUNT][10] = { 
+      const uint8_t interface_pins[INTERFACE_COUNT][10] = {
                   // SX1262
           {
                7, // pin_ss
@@ -784,15 +834,15 @@
       };
       #elif BOARD_VARIANT == MODEL_A5 || BOARD_VARIANT == MODEL_AA
       const uint8_t interfaces[INTERFACE_COUNT] = {SX1278};
-      const bool interface_cfg[INTERFACE_COUNT][3] = { 
+      const bool interface_cfg[INTERFACE_COUNT][3] = {
                     // SX1278
           {
               false, // DEFAULT_SPI
               false, // HAS_TCXO
               false  // DIO2_AS_RF_SWITCH
-          }, 
+          },
       };
-      const uint8_t interface_pins[INTERFACE_COUNT][10] = { 
+      const uint8_t interface_pins[INTERFACE_COUNT][10] = {
                   // SX1278
           {
                7, // pin_ss
@@ -807,18 +857,18 @@
               -1  // pin_tcxo_enable
           }
       };
-      #elif BOARD_VARIANT == MODEL_AC // SX1280 with PA 
+      #elif BOARD_VARIANT == MODEL_AC // SX1280 with PA
       #define CONFIG_QUEUE_0_SIZE 6144
       const uint8_t interfaces[INTERFACE_COUNT] = {SX1280};
-      const bool interface_cfg[INTERFACE_COUNT][3] = { 
+      const bool interface_cfg[INTERFACE_COUNT][3] = {
                     // SX1280
           {
               false, // DEFAULT_SPI
               false, // HAS_TCXO
               false  // DIO2_AS_RF_SWITCH
-          }, 
+          },
       };
-      const uint8_t interface_pins[INTERFACE_COUNT][10] = { 
+      const uint8_t interface_pins[INTERFACE_COUNT][10] = {
                   // SX1280
           {
                7, // pin_ss
@@ -834,7 +884,7 @@
           }
       };
       #endif
-      
+
       const int pin_np = 38;
       const int pin_dac = 25;
       const int pin_adc = 1;
@@ -873,7 +923,7 @@
 
       const int pin_poweron = 10;
       const int pin_btn_usr1 = 0;
-      
+
       const int SD_MISO = 38;
       const int SD_MOSI = 41;
       const int SD_CLK = 40;
@@ -889,15 +939,15 @@
       #define INTERFACE_COUNT 1
 
       const uint8_t interfaces[INTERFACE_COUNT] = {SX1262};
-      const bool interface_cfg[INTERFACE_COUNT][3] = { 
+      const bool interface_cfg[INTERFACE_COUNT][3] = {
                     // SX1262
           {
               false, // DEFAULT_SPI
               true, // HAS_TCXO
               true  // DIO2_AS_RF_SWITCH
-          }, 
+          },
       };
-      const uint8_t interface_pins[INTERFACE_COUNT][10] = { 
+      const uint8_t interface_pins[INTERFACE_COUNT][10] = {
                   // SX1262
           {
                9, // pin_ss
@@ -939,13 +989,13 @@
 
       #define HAS_INPUT true
       #define HAS_SLEEP false
-      
+
       #define PMU_IRQ 40
       #define I2C_SCL 41
       #define I2C_SDA 42
 
       const int pin_btn_usr1 = 0;
-      
+
       const int SD_MISO = 37;
       const int SD_MOSI = 35;
       const int SD_CLK = 36;
@@ -956,15 +1006,15 @@
       #define INTERFACE_COUNT 1
 
       const uint8_t interfaces[INTERFACE_COUNT] = {SX1262};
-      const bool interface_cfg[INTERFACE_COUNT][3] = { 
+      const bool interface_cfg[INTERFACE_COUNT][3] = {
                     // SX1262
           {
               false, // DEFAULT_SPI
               true, // HAS_TCXO
               true  // DIO2_AS_RF_SWITCH
-          }, 
+          },
       };
-      const uint8_t interface_pins[INTERFACE_COUNT][10] = { 
+      const uint8_t interface_pins[INTERFACE_COUNT][10] = {
                   // SX1262
           {
               10, // pin_ss
@@ -996,7 +1046,7 @@
       // currently there is only support for using one Bluetooth type,
       // Bluetooth has been chosen over BLE as it is less experimental
       #define HAS_BLUETOOTH true
-      //#define HAS_BLE true 
+      //#define HAS_BLE true
       #define HAS_CONSOLE true
       #define HAS_SD false
       #define HAS_EEPROM true
@@ -1007,15 +1057,15 @@
       const int pin_led_tx = 4;
 
       const uint8_t interfaces[INTERFACE_COUNT] = {SX1262};
-      const bool interface_cfg[INTERFACE_COUNT][3] = { 
+      const bool interface_cfg[INTERFACE_COUNT][3] = {
                     // SX1262
           {
               true, // DEFAULT_SPI
               true, // HAS_TCXO
               true  // DIO2_AS_RF_SWITCH
-          }, 
+          },
       };
-      const int8_t interface_pins[INTERFACE_COUNT][10] = { 
+      const int8_t interface_pins[INTERFACE_COUNT][10] = {
                   // SX1262
           {
               18, // pin_ss
@@ -1060,15 +1110,15 @@
       const int pin_btn_usr1 = 21;
 
       const uint8_t interfaces[INTERFACE_COUNT] = {SX1262};
-      const bool interface_cfg[INTERFACE_COUNT][3] = { 
+      const bool interface_cfg[INTERFACE_COUNT][3] = {
                     // SX1262
           {
               true, // DEFAULT_SPI
               true, // HAS_TCXO
               true  // DIO2_AS_RF_SWITCH
-          }, 
+          },
       };
-      const int8_t interface_pins[INTERFACE_COUNT][10] = { 
+      const int8_t interface_pins[INTERFACE_COUNT][10] = {
                   // SX1262
           {
               41, // pin_ss
@@ -1106,7 +1156,7 @@
     #else
       #error An unsupported ESP32 board was selected. Cannot compile RNode firmware.
     #endif
-  
+
   #elif MCU_VARIANT == MCU_NRF52
     #define CONFIG_UART_BUFFER_SIZE 6144
     #define CONFIG_QUEUE_0_SIZE 6144
@@ -1137,7 +1187,7 @@
       #define HAS_BACKLIGHT true
       // first interface in list is the primary
       const uint8_t interfaces[INTERFACE_COUNT] = {SX1262};
-      const bool interface_cfg[INTERFACE_COUNT][3] = { 
+      const bool interface_cfg[INTERFACE_COUNT][3] = {
                   // SX1262
           {
               false, // DEFAULT_SPI
@@ -1146,10 +1196,10 @@
           }
       };
 
-      const int8_t interface_pins[INTERFACE_COUNT][10] = { 
+      const int8_t interface_pins[INTERFACE_COUNT][10] = {
                   // SX1262
           {
-              24, // pin_ss 
+              24, // pin_ss
               19, // pin_sclk
               22, // pin_mosi
               23, // pin_miso
@@ -1191,7 +1241,7 @@
 
     #elif BOARD_MODEL == BOARD_RAK4631 || BOARD_MODEL == BOARD_OPENCOM_XL
       #define HAS_EEPROM false
-      #define HAS_DISPLAY false 
+      #define HAS_DISPLAY false
       #define HAS_BLUETOOTH false
       #define HAS_BLE true
       #define HAS_CONSOLE false
@@ -1212,7 +1262,7 @@
 
       // first interface in list is the primary
       const uint8_t interfaces[INTERFACE_COUNT] = {SX1262};
-      const bool interface_cfg[INTERFACE_COUNT][3] = { 
+      const bool interface_cfg[INTERFACE_COUNT][3] = {
                     // SX1262
           {
               false, // DEFAULT_SPI
@@ -1220,7 +1270,7 @@
               true  // DIO2_AS_RF_SWITCH
           }
       };
-      const int8_t interface_pins[INTERFACE_COUNT][10] = { 
+      const int8_t interface_pins[INTERFACE_COUNT][10] = {
                   // SX1262
           {
               42, // pin_ss
@@ -1248,21 +1298,21 @@
 
       // first interface in list is the primary
       const uint8_t interfaces[INTERFACE_COUNT] = {SX1262, SX1280};
-      const bool interface_cfg[INTERFACE_COUNT][3] = { 
+      const bool interface_cfg[INTERFACE_COUNT][3] = {
                     // SX1262
           {
               false, // DEFAULT_SPI
               true, // HAS_TCXO
               true  // DIO2_AS_RF_SWITCH
-          }, 
+          },
                     // SX1280
           {
               true, // DEFAULT_SPI
               false,// HAS_TCXO
               false // DIO2_AS_RF_SWITCH
-          } 
+          }
       };
-      const int8_t interface_pins[INTERFACE_COUNT][10] = { 
+      const int8_t interface_pins[INTERFACE_COUNT][10] = {
                   // SX1262
           {
               42, // pin_ss
@@ -1288,7 +1338,7 @@
               20, // pin_txen
               19, // pin_rxen
               -1  // pin_tcxo_enable
-          } 
+          }
       };
 
       #endif
@@ -1359,7 +1409,7 @@
       #define INTERFACE_COUNT 1
 
       const uint8_t interfaces[INTERFACE_COUNT] = {SX1262};
-      const bool interface_cfg[INTERFACE_COUNT][3] = { 
+      const bool interface_cfg[INTERFACE_COUNT][3] = {
                     // SX1262
           {
               false, // DEFAULT_SPI
@@ -1367,7 +1417,7 @@
               true  // DIO2_AS_RF_SWITCH
           }
       };
-      const int8_t interface_pins[INTERFACE_COUNT][10] = { 
+      const int8_t interface_pins[INTERFACE_COUNT][10] = {
                   // SX1262
           {
               24, // pin_ss
@@ -1387,7 +1437,7 @@
       #define HAS_GPS true
       #define GPS_BAUD_RATE 9600
       #define PIN_GPS_RX 37
-      #define PIN_GPS_TX 39 
+      #define PIN_GPS_TX 39
       #endif
     #else
       #error An unsupported nRF board was selected. Cannot compile RNode firmware.
@@ -1406,7 +1456,7 @@
   #ifndef LED_ON
     #define LED_ON HIGH
   #endif
-  
+
   #ifndef LED_OFF
     #define LED_OFF LOW
   #endif

--- a/Documentation/BUILDING.md
+++ b/Documentation/BUILDING.md
@@ -4,7 +4,7 @@ The build system of this repository is based on GNU Make. The `Makefile` is in t
 
 Firstly, figure out which MCU platform your supported board is based on. The table below can help you.
 
-| Board name | Link | Transceiver | MCU | Description | 
+| Board name | Link | Transceiver | MCU | Description |
 | :--- | :---: | :---: | :---: | :---: |
 | Handheld v2.x RNodes | [Buy here](https://unsigned.io/shop/product/handheld-rnode) | SX1276 | ESP32 |
 | RAK4631 | [Buy here](https://store.rakwireless.com/products/rak4631-lpwan-node?m=5&h=wisblock-core) | SX1262 | nRF52 |
@@ -13,7 +13,7 @@ Firstly, figure out which MCU platform your supported board is based on. The tab
 | LilyGO LoRa32 v2.0 | No link | SX1276/8 | ESP32 | Discontinued? |
 | LilyGO LoRa32 v2.1 |  [Buy here](https://www.lilygo.cc/products/lora3) | SX1276/8 | ESP32 | With and without TCXO |
 | Heltec LoRa32 v2 | No link | SX1276/8 | ESP32 | Discontinued? |
-| Heltec LoRa32 v3 | [Buy here](https://heltec.org/project/wifi-lora-32-v3/) | SX1262 | ESP32 | 
+| Heltec LoRa32 v3 | [Buy here](https://heltec.org/project/wifi-lora-32-v3/) | SX1262 | ESP32 |
 | Homebrew ESP32 boards | | Any supported | ESP32 | This can be any board with an Adafruit Feather (or generic) ESP32 chip |
 
 ### ESP32
@@ -24,7 +24,7 @@ If your board is nRF52-based, please run `make prep-nrf` to install the required
 
 ## Compiling
 Next, you need to find the name of the target for your board. Please reference the table below to do so:
-| Board name | Target | 
+| Board name | Target |
 | :--- | :---: |
 | Handheld v2.x RNodes | `rnode_ng_20` |
 | RAK4631 | `rak4631` |
@@ -34,7 +34,7 @@ Next, you need to find the name of the target for your board. Please reference t
 | LilyGO LoRa32 v2.0 | `lora32_v20` |
 | LilyGO LoRa32 v2.1 | `lora32_v21` |
 | Heltec LoRa32 v2 | `heltec32_v2` |
-| Heltec LoRa32 v3 | `heltec32_v3` | 
+| Heltec LoRa32 v3 | `heltec32_v3` |
 | Homebrew ESP32 boards | `genericesp32` |
 
 After you've ascertained the target for the board simply run the following to compile for the board:
@@ -107,6 +107,8 @@ PRODUCT_H32_V3 = 0xC1
 PRODUCT_TBEAM  = 0xE0
 PRODUCT_HMBRW  = 0xF0
 ```
+
+For an up-to-date list of Products and Models, please check the source code in `rnodeconf`.
 
 **Please note**, you must re-compile the firmware each time you make changes **before** you flash it, else you will just be flashing the previous version of the firmware without the new changes!
 

--- a/Documentation/CONTRIBUTING.md
+++ b/Documentation/CONTRIBUTING.md
@@ -28,15 +28,15 @@ The board definition should look as follows:
       const int pin_led_rx = 9;
       const int pin_led_tx = 8;
       const uint8_t interfaces[INTERFACE_COUNT] = {SX127X};
-      const bool interface_cfg[INTERFACE_COUNT][3] = { 
+      const bool interface_cfg[INTERFACE_COUNT][3] = {
                     // SX127X
           {
               true, // DEFAULT_SPI
               false, // HAS_TCXO
               false  // DIO2_AS_RF_SWITCH
-          }, 
+          },
       };
-      const int8_t interface_pins[INTERFACE_COUNT][10] = { 
+      const int8_t interface_pins[INTERFACE_COUNT][10] = {
                   // SX127X
           {
               7, // pin_ss
@@ -85,7 +85,7 @@ An example of an entry using the SX1262 modem can be seen below:
   const int pin_led_tx = 6;
   #define INTERFACE_COUNT 1
   const uint8_t interfaces[INTERFACE_COUNT] = {SX126X};
-  const bool interface_cfg[INTERFACE_COUNT][3] = { 
+  const bool interface_cfg[INTERFACE_COUNT][3] = {
                 // SX1262
       {
           false, // DEFAULT_SPI
@@ -93,7 +93,7 @@ An example of an entry using the SX1262 modem can be seen below:
           true  // DIO2_AS_RF_SWITCH
       }
   };
-  const int8_t interface_pins[INTERFACE_COUNT][10] = { 
+  const int8_t interface_pins[INTERFACE_COUNT][10] = {
               // SX1262
       {
           42, // pin_ss
@@ -126,15 +126,15 @@ An example of an entry using the SX1280 modem can be seen below:
   const int pin_led_tx = 6;
   #define INTERFACE_COUNT 1
   const uint8_t interfaces[INTERFACE_COUNT] = {SX128X};
-  const bool interface_cfg[INTERFACE_COUNT][3] = { 
+  const bool interface_cfg[INTERFACE_COUNT][3] = {
                 // SX1280
       {
           true, // DEFAULT_SPI
           false,// HAS_TCXO
           false // DIO2_AS_RF_SWITCH
-      } 
+      }
   };
-  const int8_t interface_pins[INTERFACE_COUNT][10] = { 
+  const int8_t interface_pins[INTERFACE_COUNT][10] = {
               // SX1280
       {
           24, // pin_ss
@@ -147,7 +147,7 @@ An example of an entry using the SX1280 modem can be seen below:
           20, // pin_txen
           19, // pin_rxen
           -1  // pin_tcxo_enable
-      } 
+      }
   };
 ```
 
@@ -158,9 +158,9 @@ If you are using non-default SPI pins on an nRF52 MCU variant, you **must** ensu
       const SPIClass interface_spi[1] = {
             // SX1262
             SPIClass(
-                NRF_SPIM2, 
-                interface_pins[0][3], 
-                interface_pins[0][1], 
+                NRF_SPIM2,
+                interface_pins[0][3],
+                interface_pins[0][1],
                 interface_pins[0][2]
                )
       };
@@ -180,6 +180,19 @@ Note: this will again have to be pasted in the correct section according to
 your MCU variant. Please search for the other definitions of `led_rx_on()` to
 find the correct section, then find the final section by searching for the
 comparison where `MCU_VARIANT` is checked for your MCU variant.
+
+The product ID needs to be added to the validation functions `eeprom_product_valid()`, under the correct platform:
+```
+#if PLATFORM == PLATFORM_ESP32
+if (rval == PRODUCT_RNODE || ... || rval == BOARD_MY_WICKED_BOARD
+```
+
+The same must be done for the models under `eeprom_model_valid()`.
+Make sure you add all the model variants you want to support as defined at the top of `Boards.h`.
+```
+#elif BOARD_MODEL == BOARD_MY_WICKED_BOARD
+if (model == MODEL_FE || model == MODEL_FF) {
+```
 
 ### Makefile
 You can add the example target below to the makefile for your board, but **you must replace the FQBN** in the arduino-cli command with the correct one for your board.
@@ -238,4 +251,4 @@ Please submit this, and any other support in different areas of the project your
 Feature requests are welcomed, given that those requesting it are happy to write it themselves, or a contributor considers it to be important enough to them to write it themselves. They must be written and **properly** tested before being proposed as a pull request for the project on [GitHub](https://github.com/liberatedsystems/RNode_Firmware_CE). **Manufacturers are encouraged to contribute support for their products back to this repository**, and such support will be received gladly, given it does not effect support for other products or boards.
 
 # Caveat
-All contributions must not be written using **any** LLM (ChatGPT, etc.), please handwrite them **only**. Any PRs with proposed contributions which have been discovered to be written using an LLM will **NOT** be merged. The contributor concerned may rewrite their entire pull request **by hand** and it may be reconsidered for merging in the future. 
+All contributions must not be written using **any** LLM (ChatGPT, etc.), please handwrite them **only**. Any PRs with proposed contributions which have been discovered to be written using an LLM will **NOT** be merged. The contributor concerned may rewrite their entire pull request **by hand** and it may be reconsidered for merging in the future.

--- a/Makefile
+++ b/Makefile
@@ -25,13 +25,21 @@ endif
 COMMON_BUILD_FLAGS =  $(VFLAG) -e --build-property "build.partitions=no_ota" --build-property "upload.maximum_size=2097152"
 COMMON_ESP_UPLOAD_FLAGS = $(VFLAG) --chip esp32 --baud 921600 --before default_reset --after hard_reset write_flash -z --flash_mode dio --flash_freq 80m --flash_size 4MB 0x210000
 
+VENV_BIN = .venv/bin
+PIP = $(VENV_BIN)/pip
+PYTHON = $(VENV_BIN)/python
+
+venv:
+	test -d .venv || python3 -m venv .venv
+
 all: release
 
 clean:
 	-rm -rf ./build
 	-rm -f ./Release/rnode_firmware*
+	-rm -r ./.venv
 
-prep: prep-esp32 prep-nrf
+prep: venv prep-esp32 prep-nrf
 
 prep-index:
 	arduino-cli core update-index --config-file arduino-cli.yaml
@@ -45,7 +53,7 @@ prep-esp32:
 	arduino-cli lib install "XPowersLib"
 	arduino-cli lib install "Crypto"
 	arduino-cli lib install "Adafruit NeoPixel"
-	pip install pyserial rns --upgrade --user --break-system-packages # This looks scary, but it's actually just telling pip to install packages as a user instead of trying to install them systemwide, which bypasses the "externally managed environment" error.
+	$(PIP) --require-virtualenv install pyserial rns
 
 prep-nrf:
 	arduino-cli core install adafruit:nrf52 --config-file arduino-cli.yaml
@@ -57,8 +65,8 @@ prep-nrf:
 	arduino-cli lib install "TinyGPSPlus"
 	arduino-cli config set library.enable_unsafe_install true
 	arduino-cli lib install --git-url https://github.com/liamcottle/esp8266-oled-ssd1306#e16cee124fe26490cb14880c679321ad8ac89c95
-	pip install pyserial rns --upgrade --user --break-system-packages # This looks scary, but it's actually just telling pip to install packages as a user instead of trying to install them systemwide, which bypasses the "externally managed environment" error.
-	pip install adafruit-nrfutil --upgrade --user --break-system-packages # This looks scary, but it's actually just telling pip to install packages as a user instead of trying to install them systemwide, which bypasses the "externally managed environment" error.
+	$(PIP) --require-virtualenv install pyserial rns
+	$(PIP) --require-virtualenv install adafruit-nrfutil
 
 console-site:
 	make -C Console clean site
@@ -66,11 +74,11 @@ console-site:
 spiffs: console-site spiffs-image
 
 spiffs-image:
-	python3 Release/esptool/spiffsgen.py 1966080 ./Console/build Release/console_image.bin
+	$(PYTHON) Release/esptool/spiffsgen.py 1966080 ./Console/build Release/console_image.bin
 
 upload-spiffs:
 	@echo Deploying SPIFFS image...
-	python ./Release/esptool/esptool.py --port $(or $(port), /dev/ttyACM0) $(COMMON_UPLOAD_FLAGS) ./Release/console_image.bin
+	$(PYTHON) ./Release/esptool/esptool.py --port $(or $(port), /dev/ttyACM0) $(COMMON_UPLOAD_FLAGS) ./Release/console_image.bin
 
 firmware: $(shell grep ^firmware- Makefile | cut -d: -f1)
 
@@ -125,6 +133,9 @@ firmware-heltec32_v2_extled: check_bt_buffers
 firmware-heltec32_v3:
 	arduino-cli compile --fqbn esp32:esp32:heltec_wifi_lora_32_V3 $(COMMON_BUILD_FLAGS) --build-property "compiler.cpp.extra_flags=\"-DBOARD_MODEL=0x3A\""
 
+firmware-heltec_wsl_v3:
+	arduino-cli compile --fqbn esp32:esp32:heltec_wifi_lora_32_V3 $(COMMON_BUILD_FLAGS) --build-property "compiler.cpp.extra_flags=\"-DBOARD_MODEL=0xCD\""
+
 firmware-heltec_w_paper:
 	arduino-cli compile --fqbn esp32:esp32:heltec_wifi_lora_32_V3 $(COMMON_BUILD_FLAGS) --build-property "compiler.cpp.extra_flags=\"-DBOARD_MODEL=0x3E\""
 
@@ -161,128 +172,128 @@ firmware-heltec_t114_gps:
 upload-tbeam:
 	arduino-cli upload -p $(or $(port), /dev/ttyACM0) --fqbn esp32:esp32:t-beam
 	@sleep 1
-	rnodeconf $(or $(port), /dev/ttyACM0) --firmware-hash $$(./partition_hashes ./build/esp32.esp32.t-beam/RNode_Firmware_CE.ino.bin)
+	$(VENV_BIN)/rnodeconf $(or $(port), /dev/ttyACM0) --firmware-hash $$($(PYTHON) ./partition_hashes ./build/esp32.esp32.t-beam/RNode_Firmware_CE.ino.bin)
 	@sleep 3
-	python3 ./Release/esptool/esptool.py --port $(or $(port), /dev/ttyACM0) $(COMMON_ESP_UPLOAD_FLAGS) ./Release/console_image.bin
+	$(PYTHON) ./Release/esptool/esptool.py --port $(or $(port), /dev/ttyACM0) $(COMMON_ESP_UPLOAD_FLAGS) ./Release/console_image.bin
 
 upload-tbeam_sx1262:
-	arduino-cli upload -p /dev/ttyACM0 --fqbn esp32:esp32:t-beam
+	arduino-cli upload -p $(or $(port), /dev/ttyACM0) --fqbn esp32:esp32:t-beam
 	@sleep 1
-	rnodeconf /dev/ttyACM0 --firmware-hash $$(./partition_hashes ./build/esp32.esp32.t-beam/RNode_Firmware_CE.ino.bin)
+	$(VENV_BIN)/rnodeconf $(or $(port), /dev/ttyACM0) --firmware-hash $$($(PYTHON) ./partition_hashes ./build/esp32.esp32.t-beam/RNode_Firmware_CE.ino.bin)
 	#@sleep 3
-	#python ./Release/esptool/esptool.py --chip esp32 --port /dev/ttyACM0 --baud 921600 --before default_reset --after hard_reset write_flash -z --flash_mode dio --flash_freq 80m --flash_size 4MB 0x210000 ./Release/console_image.bin
+	#$(PYTHON) ./Release/esptool/esptool.py --chip esp32 --port $(or $(port), /dev/ttyACM0) --baud 921600 --before default_reset --after hard_reset write_flash -z --flash_mode dio --flash_freq 80m --flash_size 4MB 0x210000 ./Release/console_image.bin
 
 upload-lora32_v10:
 	arduino-cli upload -p $(or $(port), /dev/ttyUSB0) --fqbn esp32:esp32:ttgo-lora32
 	@sleep 1
-	rnodeconf $(or $(port), /dev/ttyUSB0) --firmware-hash $$(./partition_hashes ./build/esp32.esp32.ttgo-lora32/RNode_Firmware_CE.ino.bin)
+	$(VENV_BIN)/rnodeconf $(or $(port), /dev/ttyUSB0) --firmware-hash $$($(PYTHON) ./partition_hashes ./build/esp32.esp32.ttgo-lora32/RNode_Firmware_CE.ino.bin)
 	@sleep 3
-	python3 ./Release/esptool/esptool.py --port $(or $(port), /dev/ttyUSB0) $(COMMON_ESP_UPLOAD_FLAGS) ./Release/console_image.bin
+	$(PYTHON) ./Release/esptool/esptool.py --port $(or $(port), /dev/ttyUSB0) $(COMMON_ESP_UPLOAD_FLAGS) ./Release/console_image.bin
 
 upload-lora32_v20:
 	arduino-cli upload -p $(or $(port), /dev/ttyUSB0) --fqbn esp32:esp32:ttgo-lora32
 	@sleep 1
-	rnodeconf $(or $(port), /dev/ttyUSB0) --firmware-hash $$(./partition_hashes ./build/esp32.esp32.ttgo-lora32/RNode_Firmware_CE.ino.bin)
+	$(VENV_BIN)/rnodeconf $(or $(port), /dev/ttyUSB0) --firmware-hash $$($(PYTHON) ./partition_hashes ./build/esp32.esp32.ttgo-lora32/RNode_Firmware_CE.ino.bin)
 	@sleep 3
-	python3 ./Release/esptool/esptool.py --port $(or $(port), /dev/ttyUSB0) $(COMMON_ESP_UPLOAD_FLAGS) ./Release/console_image.bin
+	$(PYTHON) ./Release/esptool/esptool.py --port $(or $(port), /dev/ttyUSB0) $(COMMON_ESP_UPLOAD_FLAGS) ./Release/console_image.bin
 
 upload-lora32_v21:
 	arduino-cli upload -p $(or $(port), /dev/ttyACM0) --fqbn esp32:esp32:ttgo-lora32
 	@sleep 1
-	rnodeconf $(or $(port), /dev/ttyACM0) --firmware-hash $$(./partition_hashes ./build/esp32.esp32.ttgo-lora32/RNode_Firmware_CE.ino.bin)
+	$(VENV_BIN)/rnodeconf $(or $(port), /dev/ttyACM0) --firmware-hash $$($(PYTHON) ./partition_hashes ./build/esp32.esp32.ttgo-lora32/RNode_Firmware_CE.ino.bin)
 	@sleep 3
-	python3 ./Release/esptool/esptool.py --port $(or $(port), /dev/ttyACM0) $(COMMON_ESP_UPLOAD_FLAGS) ./Release/console_image.bin
+	$(PYTHON) ./Release/esptool/esptool.py --port $(or $(port), /dev/ttyACM0) $(COMMON_ESP_UPLOAD_FLAGS) ./Release/console_image.bin
 
 upload-heltec32_v2:
 	arduino-cli upload -p $(or $(port), /dev/ttyUSB0) --fqbn esp32:esp32:heltec_wifi_lora_32_V2
 	@sleep 1
-	rnodeconf $(or $(port), /dev/ttyUSB0) --firmware-hash $$(./partition_hashes ./build/esp32.esp32.heltec_wifi_lora_32_V2/RNode_Firmware_CE.ino.bin)
+	$(VENV_BIN)/rnodeconf $(or $(port), /dev/ttyUSB0) --firmware-hash $$($(PYTHON) ./partition_hashes ./build/esp32.esp32.heltec_wifi_lora_32_V2/RNode_Firmware_CE.ino.bin)
 	@sleep 3
-	python3 ./Release/esptool/esptool.py --port $(or $(port), /dev/ttyUSB0) $(COMMON_ESP_UPLOAD_FLAGS) ./Release/console_image.bin
+	$(PYTHON) ./Release/esptool/esptool.py --port $(or $(port), /dev/ttyUSB0) $(COMMON_ESP_UPLOAD_FLAGS) ./Release/console_image.bin
 
-upload-heltec_w_paper upload-heltec32_v3:
+upload-heltec_w_paper upload-heltec32_v3 upload-heltec_wsl_v3:
 	arduino-cli upload -p $(or $(port), /dev/ttyUSB0) --fqbn esp32:esp32:heltec_wifi_lora_32_V3
 	@sleep 1
-	rnodeconf $(or $(port), /dev/ttyUSB0) --firmware-hash $$(./partition_hashes ./build/esp32.esp32.heltec_wifi_lora_32_V3/RNode_Firmware_CE.ino.bin)
+	$(VENV_BIN)/rnodeconf $(or $(port), /dev/ttyUSB0) --firmware-hash $$($(PYTHON) ./partition_hashes ./build/esp32.esp32.heltec_wifi_lora_32_V3/RNode_Firmware_CE.ino.bin)
 	@sleep 3
-	python3 ./Release/esptool/esptool.py --port $(or $(port), /dev/ttyUSB0) --chip esp32-s3 --baud 921600 --before default_reset --after hard_reset write_flash -z --flash_mode dio --flash_freq 80m --flash_size 4MB 0x210000 ./Release/console_image.bin
+	$(PYTHON) ./Release/esptool/esptool.py --port $(or $(port), /dev/ttyUSB0) --chip esp32-s3 --baud 921600 --before default_reset --after hard_reset write_flash -z --flash_mode dio --flash_freq 80m --flash_size 4MB 0x210000 ./Release/console_image.bin
 
 upload-xiao_esp32s3:
 	arduino-cli upload -p $(or $(port), /dev/ttyACM0) --fqbn esp32:esp32:XIAO_ESP32S3
 	@sleep 1
-	rnodeconf $(or $(port), /dev/ttyACM0) --firmware-hash $$(./partition_hashes ./build/esp32.esp32.XIAO_ESP32S3/RNode_Firmware_CE.ino.bin)
+	$(VENV_BIN)/rnodeconf $(or $(port), /dev/ttyACM0) --firmware-hash $$($(PYTHON) ./partition_hashes ./build/esp32.esp32.XIAO_ESP32S3/RNode_Firmware_CE.ino.bin)
 	@sleep 3
-	python ./Release/esptool/esptool.py --port $(or $(port), /dev/ttyACM0) --chip esp32-s3 --baud 921600 --before default_reset --after hard_reset write_flash -z --flash_mode dio --flash_freq 80m --flash_size 8MB 0x210000 ./Release/console_image.bin
+	$(PYTHON) ./Release/esptool/esptool.py --port $(or $(port), /dev/ttyACM0) --chip esp32-s3 --baud 921600 --before default_reset --after hard_reset write_flash -z --flash_mode dio --flash_freq 80m --flash_size 8MB 0x210000 ./Release/console_image.bin
 
 
 upload-tdeck:
 	arduino-cli upload -p $(or $(port), /dev/ttyACM0) --fqbn esp32:esp32:esp32s3
 	@sleep 1
-	rnodeconf $(or $(port), /dev/ttyACM0) --firmware-hash $$(./partition_hashes ./build/esp32.esp32.esp32s3/RNode_Firmware_CE.ino.bin)
+	$(VENV_BIN)/rnodeconf $(or $(port), /dev/ttyACM0) --firmware-hash $$($(PYTHON) ./partition_hashes ./build/esp32.esp32.esp32s3/RNode_Firmware_CE.ino.bin)
 	@sleep 3
 	python ./Release/esptool/esptool.py --port $(or $(port), /dev/ttyACM0) --chip esp32-s3 --baud 921600 --before default_reset --after hard_reset write_flash -z --flash_mode dio --flash_freq 80m --flash_size 4MB 0x210000 ./Release/console_image.bin
 
 upload-tbeam_supreme:
 	arduino-cli upload -p $(or $(port), /dev/ttyACM0) --fqbn esp32:esp32:esp32s3
 	@sleep 1
-	rnodeconf $(or $(port), /dev/ttyACM0) --firmware-hash $$(./partition_hashes ./build/esp32.esp32.esp32s3/RNode_Firmware_CE.ino.bin)
+	$(VENV_BIN)/rnodeconf $(or $(port), /dev/ttyACM0) --firmware-hash $$($(PYTHON) ./partition_hashes ./build/esp32.esp32.esp32s3/RNode_Firmware_CE.ino.bin)
 	@sleep 3
-	python ./Release/esptool/esptool.py --port $(or $(port), /dev/ttyACM0) --chip esp32-s3 --baud 921600 --before default_reset --after hard_reset write_flash -z --flash_mode dio --flash_freq 80m --flash_size 4MB 0x210000 ./Release/console_image.bin
+	$(PYTHON) ./Release/esptool/esptool.py --port $(or $(port), /dev/ttyACM0) --chip esp32-s3 --baud 921600 --before default_reset --after hard_reset write_flash -z --flash_mode dio --flash_freq 80m --flash_size 4MB 0x210000 ./Release/console_image.bin
 
 upload-rnode_ng_20:
 	arduino-cli upload -p $(or $(port), /dev/ttyUSB0) --fqbn esp32:esp32:ttgo-lora32
 	@sleep 1
-	rnodeconf $(or $(port), /dev/ttyUSB0) --firmware-hash $$(./partition_hashes ./build/esp32.esp32.ttgo-lora32/RNode_Firmware_CE.ino.bin)
+	$(VENV_BIN)/rnodeconf $(or $(port), /dev/ttyUSB0) --firmware-hash $$($(PYTHON) ./partition_hashes ./build/esp32.esp32.ttgo-lora32/RNode_Firmware_CE.ino.bin)
 	@sleep 3
-	python3 ./Release/esptool/esptool.py --port $(or $(port), /dev/ttyUSB0) $(COMMON_ESP_UPLOAD_FLAGS) ./Release/console_image.bin
+	$(PYTHON) ./Release/esptool/esptool.py --port $(or $(port), /dev/ttyUSB0) $(COMMON_ESP_UPLOAD_FLAGS) ./Release/console_image.bin
 
 upload-rnode_ng_21:
 	arduino-cli upload -p $(or $(port), /dev/ttyACM0) --fqbn esp32:esp32:ttgo-lora32
 	@sleep 1
-	rnodeconf $(or $(port), /dev/ttyACM0) --firmware-hash $$(./partition_hashes ./build/esp32.esp32.ttgo-lora32/RNode_Firmware_CE.ino.bin)
+	$(VENV_BIN)/rnodeconf $(or $(port), /dev/ttyACM0) --firmware-hash $$($(PYTHON) ./partition_hashes ./build/esp32.esp32.ttgo-lora32/RNode_Firmware_CE.ino.bin)
 	@sleep 3
-	python3 ./Release/esptool/esptool.py --port $(or $(port), /dev/ttyACM0) $(COMMON_ESP_UPLOAD_FLAGS) ./Release/console_image.bin
+	$(PYTHON) ./Release/esptool/esptool.py --port $(or $(port), /dev/ttyACM0) $(COMMON_ESP_UPLOAD_FLAGS) ./Release/console_image.bin
 
 upload-t3s3:
 	arduino-cli upload -p $(or $(port), /dev/ttyACM0) --fqbn esp32:esp32:esp32s3
 	@sleep 1
-	python ./Release/esptool/esptool.py --port $(or $(port), /dev/ttyACM0) --chip esp32-s3 --baud 921600 --before default_reset --after hard_reset write_flash -z --flash_mode dio --flash_freq 80m --flash_size 4MB 0x210000 ./Release/console_image.bin
+	$(PYTHON) ./Release/esptool/esptool.py --port $(or $(port), /dev/ttyACM0) --chip esp32-s3 --baud 921600 --before default_reset --after hard_reset write_flash -z --flash_mode dio --flash_freq 80m --flash_size 4MB 0x210000 ./Release/console_image.bin
 	@sleep 3
-	rnodeconf $(or $(port), /dev/ttyACM0) --firmware-hash $$(./partition_hashes ./build/esp32.esp32.esp32s3/RNode_Firmware_CE.ino.bin)
+	$(VENV_BIN)/rnodeconf $(or $(port), /dev/ttyACM0) --firmware-hash $$($(PYTHON) ./partition_hashes ./build/esp32.esp32.esp32s3/RNode_Firmware_CE.ino.bin)
 
 upload-featheresp32:
 	arduino-cli upload -p $(or $(port), /dev/ttyUSB0) --fqbn esp32:esp32:featheresp32
 	@sleep 1
-	rnodeconf $(or $(port), /dev/ttyUSB0) --firmware-hash $$(./partition_hashes ./build/esp32.esp32.featheresp32/RNode_Firmware_CE.ino.bin)
+	$(VENV_BIN)/rnodeconf $(or $(port), /dev/ttyUSB0) --firmware-hash $$($(PYTHON) ./partition_hashes ./build/esp32.esp32.featheresp32/RNode_Firmware_CE.ino.bin)
 	@sleep 3
-	python ./Release/esptool/esptool.py --port $(or $(port), /dev/ttyUSB0) $(COMMON_UPLOAD_FLAGS) ./Release/console_image.bin
+	$(PYTHON) ./Release/esptool/esptool.py --port $(or $(port), /dev/ttyUSB0) $(COMMON_UPLOAD_FLAGS) ./Release/console_image.bin
 
 upload-opencom-xl upload-rak4631:
 	arduino-cli upload -p $(or $(port), /dev/ttyACM0) --fqbn rakwireless:nrf52:WisCoreRAK4631Board
 	unzip -o build/rakwireless.nrf52.WisCoreRAK4631Board/RNode_Firmware_CE.ino.zip -d build/rakwireless.nrf52.WisCoreRAK4631Board
-	rnodeconf $(or $(port), /dev/ttyACM0) --firmware-hash $$(sha256sum ./build/rakwireless.nrf52.WisCoreRAK4631Board/RNode_Firmware_CE.ino.bin | grep -o '^\S*')
+	$(VENV_BIN)/rnodeconf $(or $(port), /dev/ttyACM0) --firmware-hash $$(sha256sum ./build/rakwireless.nrf52.WisCoreRAK4631Board/RNode_Firmware_CE.ino.bin | grep -o '^\S*')
 
 upload-e22_esp32:
 	arduino-cli upload -p $(or $(port), /dev/ttyUSB0) --fqbn esp32:esp32:esp32
 	@sleep 1
-	rnodeconf $(or $(port), /dev/ttyUSB0) --firmware-hash $$(./partition_hashes ./build/esp32.esp32.esp32/RNode_Firmware_CE.ino.bin)
+	$(VENV_BIN)/rnodeconf $(or $(port), /dev/ttyUSB0) --firmware-hash $$($(PYTHON) ./partition_hashes ./build/esp32.esp32.esp32/RNode_Firmware_CE.ino.bin)
 	@sleep 3
-	python3 ./Release/esptool/esptool.py --port $(or $(port), /dev/ttyUSB0) $(COMMON_ESP_UPLOAD_FLAGS)  ./Release/console_image.bin
+	$(PYTHON) ./Release/esptool/esptool.py --port $(or $(port), /dev/ttyUSB0) $(COMMON_ESP_UPLOAD_FLAGS)  ./Release/console_image.bin
 
 upload-heltec_t114:
-	arduino-cli upload -p /dev/ttyACM0 --fqbn Heltec_nRF52:Heltec_nRF52:HT-n5262
+	arduino-cli upload -p $(or $(port), /dev/ttyACM0) --fqbn Heltec_nRF52:Heltec_nRF52:HT-n5262
 	@sleep 1
-	rnodeconf /dev/ttyACM0 --firmware-hash $$(./partition_hashes from_device /dev/ttyACM0)
+	$(VENV_BIN)/rnodeconf $(or $(port), /dev/ttyACM0) --firmware-hash $$($(PYTHON) ./partition_hashes from_device $(or $(port), /dev/ttyACM0))
 
 upload-techo:
-	arduino-cli upload -p /dev/ttyACM0 --fqbn adafruit:nrf52:pca10056
+	arduino-cli upload -p $(or $(port), /dev/ttyACM0) --fqbn adafruit:nrf52:pca10056
 	@sleep 6
-	rnodeconf /dev/ttyACM0 --firmware-hash $$(./partition_hashes from_device /dev/ttyACM0)
+	$(VENV_BIN)/rnodeconf $(or $(port), /dev/ttyACM0) --firmware-hash $$($(PYTHON) ./partition_hashes from_device $(or $(port), /dev/ttyACM0))
 
 release:  console-site spiffs-image $(shell grep ^release- Makefile | cut -d: -f1)
 
 release-hashes:
-	python3 ./release_hashes.py > ./Release/release.json
+	$(PYTHON) ./release_hashes.py > ./Release/release.json
 
 release-tbeam: check_bt_buffers
 	arduino-cli compile --fqbn esp32:esp32:t-beam $(COMMON_BUILD_FLAGS) --build-property "compiler.cpp.extra_flags=\"-DBOARD_MODEL=0x33\" \"-DBOARD_VARIANT=0xE4\""
@@ -379,6 +390,15 @@ release-heltec32_v3:
 	cp build/esp32.esp32.heltec_wifi_lora_32_V3/RNode_Firmware_CE.ino.bootloader.bin build/rnode_firmware_heltec32v3.bootloader
 	cp build/esp32.esp32.heltec_wifi_lora_32_V3/RNode_Firmware_CE.ino.partitions.bin build/rnode_firmware_heltec32v3.partitions
 	zip --junk-paths ./Release/rnode_firmware_heltec32v3.zip ./Release/esptool/esptool.py ./Release/console_image.bin build/rnode_firmware_heltec32v3.boot_app0 build/rnode_firmware_heltec32v3.bin build/rnode_firmware_heltec32v3.bootloader build/rnode_firmware_heltec32v3.partitions
+	rm -r build
+
+release-heltec_wsl_v3:
+	arduino-cli compile --fqbn esp32:esp32:heltec_wifi_lora_32_V3 $(COMMON_BUILD_FLAGS) --build-property "compiler.cpp.extra_flags=\"-DBOARD_MODEL=0xCD\""
+	cp ~/.arduino15/packages/esp32/hardware/esp32/$(ARDUINO_ESP_CORE_VER)/tools/partitions/boot_app0.bin build/rnode_firmware_heltecwslv3.boot_app0
+	cp build/esp32.esp32.heltec_wifi_lora_32_V3/RNode_Firmware_CE.ino.bin build/rnode_firmware_heltecwslv3.bin
+	cp build/esp32.esp32.heltec_wifi_lora_32_V3/RNode_Firmware_CE.ino.bootloader.bin build/rnode_firmware_heltecwslv3.bootloader
+	cp build/esp32.esp32.heltec_wifi_lora_32_V3/RNode_Firmware_CE.ino.partitions.bin build/rnode_firmware_heltecwslv3.partitions
+	zip --junk-paths ./Release/rnode_firmware_heltecwslv3.zip ./Release/esptool/esptool.py ./Release/console_image.bin build/rnode_firmware_heltecwslv3.boot_app0 build/rnode_firmware_heltecwslv3.bin build/rnode_firmware_heltecwslv3.bootloader build/rnode_firmware_heltecwslv3.partitions
 	rm -r build
 
 release-heltec_w_paper:
@@ -529,4 +549,3 @@ release-heltec_t114:
 	cp build/Heltec_nRF52.Heltec_nRF52.HT-n5262/RNode_Firmware_CE.ino.hex build/rnode_firmware_heltec_t114.hex
 	adafruit-nrfutil dfu genpkg --dev-type 0x0052 --application build/rnode_firmware_heltec_t114.hex Release/rnode_firmware_heltec_t114.zip
 	rm -r build
-

--- a/Radio.cpp
+++ b/Radio.cpp
@@ -7,7 +7,7 @@
 #include "Radio.hpp"
 #include "src/misc/ModemISR.h"
 
-#if PLATFORM == PLATFORM_ESP32 
+#if PLATFORM == PLATFORM_ESP32
   #if defined(ESP32) and !defined(CONFIG_IDF_TARGET_ESP32S3)
     #include "soc/rtc_wdt.h"
   #endif
@@ -112,7 +112,7 @@ sx126x::sx126x(uint8_t index, SPIClass* spi, bool tcxo, bool dio2_as_rf_switch, 
 bool sx126x::preInit() {
   pinMode(_ss, OUTPUT);
   digitalWrite(_ss, HIGH);
-  
+
   // todo: check if this change causes issues on any platforms
   #if MCU_VARIANT == MCU_ESP32
   if (_sclk != -1 && _miso != -1 && _mosi != -1 && _ss != -1) {
@@ -282,11 +282,11 @@ void sx126x::setModulationParams(uint8_t sf, uint8_t bw, uint8_t cr, int ldro) {
 
   buf[0] = sf;
   buf[1] = bw;
-  buf[2] = cr; 
+  buf[2] = cr;
   // low data rate toggle
   buf[3] = ldro;
   // unused params in LoRa mode
-  buf[4] = 0x00; 
+  buf[4] = 0x00;
   buf[5] = 0x00;
   buf[6] = 0x00;
   buf[7] = 0x00;
@@ -305,11 +305,11 @@ void sx126x::setPacketParams(uint32_t preamble, uint8_t headermode, uint8_t leng
   buf[3] = length;
   buf[4] = crc;
   // standard IQ setting (no inversion)
-  buf[5] = 0x00; 
+  buf[5] = 0x00;
   // unused params
-  buf[6] = 0x00; 
-  buf[7] = 0x00; 
-  buf[8] = 0x00; 
+  buf[6] = 0x00;
+  buf[7] = 0x00;
+  buf[8] = 0x00;
 
   executeOpcode(OP_PACKET_PARAMS_6X, buf, 9);
 }
@@ -625,19 +625,19 @@ void sx126x::onReceive(void(*callback)(uint8_t, int))
     uint8_t buf[8];
 
     // set irq masks, enable all
-    buf[0] = 0xFF; 
+    buf[0] = 0xFF;
     buf[1] = 0xFF;
 
     // set dio0 masks
     buf[2] = 0x00;
-    buf[3] = IRQ_RX_DONE_MASK_6X; 
+    buf[3] = IRQ_RX_DONE_MASK_6X;
 
     // set dio1 masks
-    buf[4] = 0x00; 
+    buf[4] = 0x00;
     buf[5] = 0x00;
 
     // set dio2 masks
-    buf[6] = 0x00; 
+    buf[6] = 0x00;
     buf[7] = 0x00;
 
     executeOpcode(OP_SET_IRQ_FLAGS_6X, buf, 8);
@@ -686,7 +686,7 @@ void sx126x::standby()
   // STDBY_RC
   byte = MODE_STDBY_RC_6X;
   }
-  executeOpcode(OP_STANDBY_6X, &byte, 1); 
+  executeOpcode(OP_STANDBY_6X, &byte, 1);
 }
 
 void sx126x::sleep()
@@ -697,7 +697,7 @@ void sx126x::sleep()
 
 void sx126x::enableTCXO() {
   if (_tcxo) {
-    #if BOARD_MODEL == BOARD_RAK4631 || BOARD_MODEL == BOARD_OPENCOM_XL || BOARD_MODEL == BOARD_HELTEC32_V3 || BOARD_MODEL == BOARD_XIAO_ESP32S3
+    #if BOARD_MODEL == BOARD_RAK4631 || BOARD_MODEL == BOARD_OPENCOM_XL || BOARD_MODEL == BOARD_HELTEC32_V3 || BOARD_MODEL == BOARD_HELTEC_WSL_V3 || BOARD_MODEL == BOARD_XIAO_ESP32S3
       uint8_t buf[4] = {MODE_TCXO_3_3V_6X, 0x00, 0x00, 0xFF};
     #elif BOARD_MODEL == BOARD_TBEAM
       uint8_t buf[4] = {MODE_TCXO_1_8V_6X, 0x00, 0x00, 0xFF};
@@ -723,7 +723,7 @@ void sx126x::disableTCXO() { }
 
 void sx126x::setTxPower(int level, int outputPin) {
     // currently no low power mode for SX1262 implemented, assuming PA boost
-    
+
     // WORKAROUND - Better Resistance of the SX1262 Tx to Antenna Mismatch, see DS_SX1261-2_V1.2 datasheet chapter 15.2
     // RegTxClampConfig = @address 0x08D8
     writeRegister(0x08D8, readRegister(0x08D8) | (0x0F << 1));
@@ -748,7 +748,7 @@ void sx126x::setTxPower(int level, int outputPin) {
 
     tx_buf[0] = level;
     tx_buf[1] = 0x02; // PA ramping time - 40 microseconds
-    
+
     executeOpcode(OP_TX_PARAMS_6X, tx_buf, 2);
 }
 
@@ -1291,18 +1291,18 @@ void sx127x::onReceive(void(*callback)(uint8_t, int)) {
   if (callback) {
     pinMode(_dio0, INPUT);
     writeRegister(REG_DIO_MAPPING_1_7X, 0x00);
-    
+
     #ifdef SPI_HAS_NOTUSINGINTERRUPT
       _spiModem->usingInterrupt(digitalPinToInterrupt(_dio0));
     #endif
-    
+
     // make function available
     extern void (*onIntRise[INTERFACE_COUNT])(void);
 
     attachInterrupt(digitalPinToInterrupt(_dio0), onIntRise[_index], RISING);
   } else {
     detachInterrupt(digitalPinToInterrupt(_dio0));
-    
+
     #ifdef SPI_HAS_NOTUSINGINTERRUPT
       _spiModem->notUsingInterrupt(digitalPinToInterrupt(_dio0));
     #endif
@@ -1426,7 +1426,7 @@ uint8_t sx127x::getCodingRate4()
     return _cr + 4;
 }
 
-void sx127x::setPreambleLength(long length) { 
+void sx127x::setPreambleLength(long length) {
   _preambleLength = length;
   writeRegister(REG_PREAMBLE_MSB_7X, (uint8_t)(length >> 8));
   writeRegister(REG_PREAMBLE_LSB_7X, (uint8_t)(length >> 0));
@@ -1553,7 +1553,7 @@ bool sx128x::preInit() {
   pinMode(_ss, OUTPUT);
   // set SS high
   digitalWrite(_ss, HIGH);
-  
+
   // todo: check if this change causes issues on any platforms
   #if MCU_VARIANT == MCU_ESP32
   if (_sclk != -1 && _miso != -1 && _mosi != -1 && _ss != -1) {
@@ -1729,11 +1729,11 @@ void sx128x::setModulationParams(uint8_t sf, uint8_t bw, uint8_t cr) {
 
   buf[0] = sf << 4;
   buf[1] = bw;
-  buf[2] = cr; 
+  buf[2] = cr;
   executeOpcode(OP_MODULATION_PARAMS_8X, buf, 3);
 
-  if (sf <= 6) { writeRegister(0x925, 0x1E); } 
-  else if (sf <= 8) { writeRegister(0x925, 0x37); } 
+  if (sf <= 6) { writeRegister(0x925, 0x1E); }
+  else if (sf <= 8) { writeRegister(0x925, 0x37); }
   else if (sf >= 9) { writeRegister(0x925, 0x32); }
   writeRegister(0x093C, 0x1);
 }
@@ -1768,10 +1768,10 @@ void sx128x::setPacketParams(uint32_t target_preamble, uint8_t headermode, uint8
   buf[2] = length;
   buf[3] = crc;
   // standard IQ setting (no inversion)
-  buf[4] = 0x40; 
+  buf[4] = 0x40;
   // unused params
-  buf[5] = 0x00; 
-  buf[6] = 0x00; 
+  buf[5] = 0x00;
+  buf[6] = 0x00;
 
   executeOpcode(OP_PACKET_PARAMS_8X, buf, 7);
 
@@ -1855,7 +1855,7 @@ int sx128x::beginPacket(int implicitHeader)
   // put in standby mode
   standby();
 
-  if (implicitHeader) { implicitHeaderMode(); } 
+  if (implicitHeader) { implicitHeaderMode(); }
   else { explicitHeaderMode(); }
 
   _payloadLength = 0;
@@ -2053,7 +2053,7 @@ void sx128x::onReceive(void(*callback)(uint8_t, int))
       uint8_t buf[8];
 
       // set irq masks, enable all
-      buf[0] = 0xFF; 
+      buf[0] = 0xFF;
       buf[1] = 0xFF;
 
       // On the SX1280, no RxDone IRQ is generated if a packet is received with
@@ -2065,14 +2065,14 @@ void sx128x::onReceive(void(*callback)(uint8_t, int))
       // header.
       // set dio0 masks
       buf[2] = 0x00;
-      buf[3] = IRQ_RX_DONE_MASK_8X | IRQ_HEADER_ERROR_MASK_8X; 
+      buf[3] = IRQ_RX_DONE_MASK_8X | IRQ_HEADER_ERROR_MASK_8X;
 
       // set dio1 masks
-      buf[4] = 0x00; 
+      buf[4] = 0x00;
       buf[5] = 0x00;
 
       // set dio2 masks
-      buf[6] = 0x00; 
+      buf[6] = 0x00;
       buf[7] = 0x00;
 
       executeOpcode(OP_SET_IRQ_FLAGS_8X, buf, 8);
@@ -2126,7 +2126,7 @@ void sx128x::standby()
           // STDBY_RC
           byte = 0x00;
     }
-      executeOpcode(OP_STANDBY_8X, &byte, 1); 
+      executeOpcode(OP_STANDBY_8X, &byte, 1);
 }
 
 void sx128x::sleep()
@@ -2147,7 +2147,7 @@ void sx128x::setTxPower(int level, int outputPin) {
     uint8_t tx_buf[2];
     #if BOARD_VARIANT == MODEL_13 || BOARD_VARIANT == MODEL_21
     // RAK4631 with WisBlock SX1280 module (LIBSYS002)
-    if (level > 27) { level = 27; } 
+    if (level > 27) { level = 27; }
     else if (level < 0) { level = 0; }
 
     _txp = level;
@@ -2251,7 +2251,7 @@ void sx128x::setTxPower(int level, int outputPin) {
 
     #elif BOARD_VARIANT == MODEL_AC
     // T3S3 SX1280 PA
-        if (level > 20) { level = 20; } 
+        if (level > 20) { level = 20; }
         else if (level < 0) { level = 0; }
 
         _txp = level;
@@ -2398,7 +2398,7 @@ uint32_t sx128x::getSignalBandwidth()
       case 0x18: return 812.5E3;
       case 0x0A: return 1625E3;
   }
-  
+
   return 0;
 }
 
@@ -2413,9 +2413,9 @@ void sx128x::optimizeModemSensitivity(){
 
 void sx128x::setSignalBandwidth(uint32_t sbw)
 {
-      if (sbw <= 203.125E3) { _bw = 0x34; } 
-      else if (sbw <= 406.25E3) { _bw = 0x26; } 
-      else if (sbw <= 812.5E3) { _bw = 0x18; } 
+      if (sbw <= 203.125E3) { _bw = 0x34; }
+      else if (sbw <= 406.25E3) { _bw = 0x26; }
+      else if (sbw <= 812.5E3) { _bw = 0x18; }
       else { _bw = 0x0A; }
 
       setModulationParams(_sf, _bw, _cr);

--- a/Utilities.h
+++ b/Utilities.h
@@ -20,7 +20,7 @@
 #include <algorithm>
 #include <iterator>
 
-#if HAS_EEPROM 
+#if HAS_EEPROM
     #include <EEPROM.h>
 #elif PLATFORM == PLATFORM_NRF52
     #include <Adafruit_LittleFS.h>
@@ -259,6 +259,13 @@ uint8_t boot_vector = 0x00;
 			void led_id_off() { }
 		#endif
 	#elif BOARD_MODEL == BOARD_HELTEC32_V3
+			void led_rx_on()  { digitalWrite(pin_led_rx, HIGH); }
+			void led_rx_off() {	digitalWrite(pin_led_rx, LOW); }
+			void led_tx_on()  { digitalWrite(pin_led_tx, HIGH); }
+			void led_tx_off() { digitalWrite(pin_led_tx, LOW); }
+			void led_id_on()  { }
+			void led_id_off() { }
+	#elif BOARD_MODEL == BOARD_HELTEC_WSL_V3
 			void led_rx_on()  { digitalWrite(pin_led_rx, HIGH); }
 			void led_rx_off() {	digitalWrite(pin_led_rx, LOW); }
 			void led_tx_on()  { digitalWrite(pin_led_tx, HIGH); }
@@ -512,7 +519,7 @@ unsigned long led_standby_ticks = 0;
 		unsigned long led_standby_wait = 350;
 		unsigned long led_console_wait = 1;
 		unsigned long led_notready_wait = 200;
-	
+
 	#else
 		uint8_t led_standby_min = 200;
 		uint8_t led_standby_max = 255;
@@ -548,7 +555,7 @@ int8_t  led_standby_direction = 0;
 
         if (led_standby_ticks > led_standby_wait) {
             led_standby_ticks = 0;
-            
+
             if (led_standby_value <= led_standby_min) {
                 led_standby_direction = 1;
             } else if (led_standby_value >= led_standby_max) {
@@ -576,7 +583,7 @@ int8_t  led_standby_direction = 0;
 
         // if (led_standby_ticks > led_console_wait) {
         // 	led_standby_ticks = 0;
-            
+
         // 	if (led_standby_value <= led_standby_min) {
         // 		led_standby_direction = 1;
         // 	} else if (led_standby_value >= led_standby_max) {
@@ -647,7 +654,7 @@ void led_indicate_not_ready() {
 
         if (led_standby_ticks > led_notready_wait) {
             led_standby_ticks = 0;
-            
+
             if (led_standby_value <= led_standby_min) {
                 led_standby_direction = 1;
             } else if (led_standby_value >= led_standby_max) {
@@ -1243,6 +1250,8 @@ void setTXPower(RadioInterface* radio, int txp) {
     if (model == MODEL_C6) radio->setTxPower(txp, PA_OUTPUT_RFO_PIN);
     if (model == MODEL_C7) radio->setTxPower(txp, PA_OUTPUT_RFO_PIN);
     if (model == MODEL_CA) radio->setTxPower(txp, PA_OUTPUT_PA_BOOST_PIN);
+	if (model == MODEL_CE) radio->setTxPower(txp, PA_OUTPUT_PA_BOOST_PIN);
+	if (model == MODEL_CF) radio->setTxPower(txp, PA_OUTPUT_PA_BOOST_PIN);
 
     if (model == MODEL_D4) radio->setTxPower(txp, PA_OUTPUT_PA_BOOST_PIN);
     if (model == MODEL_D9) radio->setTxPower(txp, PA_OUTPUT_PA_BOOST_PIN);
@@ -1285,7 +1294,7 @@ uint16_t getQueueSize(uint8_t index) {
         case 3:
             return CONFIG_QUEUE_3_SIZE;
         #endif
-        #if INTERFACE_COUNT > 4 
+        #if INTERFACE_COUNT > 4
         case 4:
             return CONFIG_QUEUE_4_SIZE;
         #endif
@@ -1481,7 +1490,7 @@ bool eeprom_product_valid() {
   #endif
 
 	#if PLATFORM == PLATFORM_ESP32
-	if (rval == PRODUCT_RNODE || rval == BOARD_RNODE_NG_20 || rval == BOARD_RNODE_NG_21 || rval == PRODUCT_HMBRW || rval == PRODUCT_TBEAM || rval == PRODUCT_T32_10 || rval == PRODUCT_T32_20 || rval == PRODUCT_T32_21 || rval == PRODUCT_H32_V2 || rval == PRODUCT_H32_V3 || rval == PRODUCT_TDECK_V1 || rval == PRODUCT_TBEAM_S_V1 || rval == PRODUCT_H_W_PAPER || rval == PRODUCT_XIAO_ESP32S3) {
+	if (rval == PRODUCT_RNODE || rval == BOARD_RNODE_NG_20 || rval == BOARD_RNODE_NG_21 || rval == PRODUCT_HMBRW || rval == PRODUCT_TBEAM || rval == PRODUCT_T32_10 || rval == PRODUCT_T32_20 || rval == PRODUCT_T32_21 || rval == PRODUCT_H32_V2 || rval == PRODUCT_H32_V3 || rval == PRODUCT_HELTEC_WSL_V3 || rval == PRODUCT_TDECK_V1 || rval == PRODUCT_TBEAM_S_V1 || rval == PRODUCT_H_W_PAPER || rval == PRODUCT_XIAO_ESP32S3) {
 	#elif PLATFORM == PLATFORM_NRF52
 	if (rval == PRODUCT_RAK4631 || rval == PRODUCT_HELTEC_T114 || rval == PRODUCT_OPENCOM_XL || rval == PRODUCT_TECHO || rval == PRODUCT_HMBRW) {
 	#else
@@ -1529,6 +1538,8 @@ bool eeprom_model_valid() {
 	if (model == MODEL_C4 || model == MODEL_C9) {
 	#elif BOARD_MODEL == BOARD_HELTEC32_V3
 	if (model == MODEL_C5 || model == MODEL_CA) {
+	#elif BOARD_MODEL == BOARD_HELTEC_WSL_V3
+	if (model == MODEL_CE || model == MODEL_CF) {
     #elif BOARD_MODEL == BOARD_H_W_PAPER
     if (model == MODEL_C8) {
     #elif BOARD_MODEL == BOARD_HELTEC_T114
@@ -1577,7 +1588,7 @@ bool eeprom_checksum_valid() {
         #endif
 		data[i] = byte;
 	}
-	
+
 	unsigned char *hash = MD5::make_hash(data, CHECKSUMMED_SIZE);
 	bool checksum_valid = true;
 	for (uint8_t i = 0; i < 16; i++) {


### PR DESCRIPTION
This PR adds support for the Heltec Wireless Stick Lite v3 (WSL V3), both LF and HF variants.
This board is almost identical to the Heltec32 V3 except it does not have a display.

I have also documented missing steps in `CONTRIBUTING.md` and `BUILDING.md`, they did not mention adding the models and products to the EEPROM validation functions.

This PR also includes my Makefile changes from #80, so it should probably be merged after that one. Alternatively if it is undesirable to do so, let me know and I will revert `Makefile` to its current iteration, just adding the new steps for this board.

Should I submit a PR for `rnodeconf` to add the models/boards/products, in order to allow correctly bootstrapping the EEPROM?

---

On a tangent, there are a lot of trailing whitespaces everywhere, so my auto-formatting fixed them, causing a bunch of non-code changes, it would probably be ideal if there was a linter action to flag or fix these issues in the future, and that contributors configured their IDEs to fix this automatically.