### PR TITLE
Support for XIAO nRF52840 & Wio-SX1262 Kit

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -51,6 +51,7 @@ prep-nrf:
 	arduino-cli core install adafruit:nrf52 --config-file arduino-cli.yaml
 	arduino-cli core install rakwireless:nrf52 --config-file arduino-cli.yaml
 	arduino-cli core install Heltec_nRF52:Heltec_nRF52 --config-file arduino-cli.yaml
+	arduino-cli core install Seeeduino:nrf52 --config-file arduino-cli.yaml
 	arduino-cli lib install "Crypto"
 	arduino-cli lib install "Adafruit GFX Library"
 	arduino-cli lib install "GxEPD2"

--- a/arduino-cli.yaml
+++ b/arduino-cli.yaml
@@ -4,3 +4,4 @@ board_manager:
   - https://liberatedsystems.co.uk/rnode-firmware-ce/esp-custom-package.json
   - https://raw.githubusercontent.com/RAKwireless/RAKwireless-Arduino-BSP-Index/main/package_rakwireless_index.json
   - https://github.com/HelTecAutomation/Heltec_nRF52/releases/download/1.7.0/package_heltec_nrf_index.json
+  - https://files.seeedstudio.com/arduino/package_seeeduino_boards_index.json


### PR DESCRIPTION
Adds support for Seeed XIAO nRF52840 development board with Wio-SX1262 LoRa module.

https://www.seeedstudio.com/XIAO-nRF52840-Wio-SX1262-Kit-for-Meshtastic-p-6400.html
https://wiki.seeedstudio.com/xiao_nrf52840&_wio_SX1262_kit_for_meshtastic/

Closes #89

tested with rnsd+nomadnet and bluetooth mode with sideband