### PR TITLE
feat: support for Wio Tracker L1

### DIFF
--- a/Boards.h
+++ b/Boards.h
@@ -109,6 +109,10 @@
   #define BOARD_OPENCOM_XL    0x52
   #define MODEL_21            0x21 // openCom XL v1, 868/915 MHz
 
+  #define PRODUCT_WIO_L1      0x18
+  #define BOARD_WIO_L1        0x53
+  #define MODEL_19            0x19 // Wio Tracker L1 Pro, 868/915 MHz
+
   #define BOARD_E22_ESP32     0x45 // Custom Ebyte E22 board design for meshtastic, source:
                                    // https://github.com/NanoVHF/Meshtastic-DIY/blob/main/Schematics/E-Byte_E22/Mesh_Ebyte_E22-XXXM30S.pdf
 
@@ -1390,6 +1394,56 @@
       #define PIN_GPS_RX 37
       #define PIN_GPS_TX 39 
       #endif
+    #elif BOARD_MODEL == BOARD_WIO_L1
+      #define HAS_EEPROM false
+      #define HAS_DISPLAY true
+      #define DISPLAY MONO_OLED
+      #define HAS_BLUETOOTH false
+      #define HAS_BLE true
+      #define HAS_CONSOLE false
+      #define HAS_PMU true
+      #define HAS_NP false
+      #define HAS_SD false
+      #define HAS_INPUT true
+      #define CONFIG_UART_BUFFER_SIZE 6144
+      #define CONFIG_QUEUE_0_SIZE 6144
+      #define CONFIG_QUEUE_MAX_LENGTH 200
+      #define EEPROM_SIZE 296
+      #define EEPROM_OFFSET EEPROM_SIZE-EEPROM_RESERVED
+      #define BLE_MANUFACTURER "Seeed"
+      #define BLE_MODEL "Wio Tracker L1"
+
+      #define INTERFACE_COUNT 1
+
+      const uint8_t interfaces[INTERFACE_COUNT] = {SX1262};
+      const bool interface_cfg[INTERFACE_COUNT][3] = {
+                    // SX1262
+          {
+              false, // DEFAULT_SPI
+              true, // HAS_TCXO
+              true  // DIO2_AS_RF_SWITCH
+          }
+      };
+      const int8_t interface_pins[INTERFACE_COUNT][10] = {
+                  // SX1262
+          {
+              4, // pin_ss
+              8, // pin_sclk
+              10, // pin_mosi
+              9, // pin_miso
+              3, // pin_busy
+              1, // pin_dio
+              2, // pin_reset
+              -1, // pin_txen
+              5, // pin_rxen
+              -1  // pin_tcxo_enable
+          }
+      };
+
+      const int pin_btn_usr1 = 29;
+      const int pin_led_rx = 11;
+      const int pin_led_tx = 11;
+
     #else
       #error An unsupported nRF board was selected. Cannot compile RNode firmware.
     #endif

--- a/Display.h
+++ b/Display.h
@@ -125,6 +125,12 @@ void busyCallback(const void* p) { display_callback(); }
   #define SCL_OLED 18
   #define SDA_OLED 17
   #define DISP_CUSTOM_ADDR false
+#elif BOARD_MODEL == BOARD_WIO_L1
+  #define DISP_RST -1
+  #define DISP_ADDR 0x3D
+  #define SCL_OLED 15
+  #define SDA_OLED 14
+  #define DISP_CUSTOM_ADDR false
 #elif BOARD_MODEL == BOARD_H_W_PAPER
   #define DISP_W 250
   #define DISP_H 122
@@ -171,6 +177,8 @@ uint32_t last_epd_full_refresh = 0;
   #elif BOARD_MODEL == BOARD_TDECK
     Adafruit_ST7789 display = Adafruit_ST7789(DISPLAY_CS, DISPLAY_DC, -1);
   #elif BOARD_MODEL == BOARD_TBEAM_S_V1
+    Adafruit_SH1106G display = Adafruit_SH1106G(DISP_W, DISP_H, &Wire, -1);
+  #elif BOARD_MODEL == BOARD_WIO_L1
     Adafruit_SH1106G display = Adafruit_SH1106G(DISP_W, DISP_H, &Wire, -1);
   #elif BOARD_MODEL == BOARD_HELTEC_T114
     ST7789Spi display(&SPI1, DISPLAY_RST, DISPLAY_DC, DISPLAY_CS);
@@ -273,7 +281,7 @@ void update_area_positions() {
 }
 
 uint8_t display_contrast = 0x00;
-#if BOARD_MODEL == BOARD_TBEAM_S_V1
+#if BOARD_MODEL == BOARD_TBEAM_S_V1 || BOARD_MODEL == BOARD_WIO_L1
   void set_contrast(Adafruit_SH1106G *display, uint8_t value) {
   }
 #elif BOARD_MODEL == BOARD_HELTEC_T114
@@ -377,6 +385,8 @@ bool display_init() {
       #endif
     #elif BOARD_MODEL == BOARD_TBEAM_S_V1
       Wire.begin(SDA_OLED, SCL_OLED);
+    #elif BOARD_MODEL == BOARD_WIO_L1
+      Wire.begin();
     #elif BOARD_MODEL == BOARD_XIAO_S3
       Wire.begin(SDA_OLED, SCL_OLED);
     #endif
@@ -431,7 +441,7 @@ bool display_init() {
     // set white as default pixel colour for Heltec T114
     display.setRGB(COLOR565(0xFF, 0xFF, 0xFF));
     if (false) {
-    #elif BOARD_MODEL == BOARD_TBEAM_S_V1
+    #elif BOARD_MODEL == BOARD_TBEAM_S_V1 || BOARD_MODEL == BOARD_WIO_L1
     if (!display.begin(display_address, true)) {
     #else
     if (!display.begin(SSD1306_SWITCHCAPVCC, display_address)) {
@@ -470,6 +480,9 @@ bool display_init() {
           #elif BOARD_MODEL == BOARD_TBEAM_S_V1
             disp_mode = DISP_MODE_PORTRAIT;
             display.setRotation(1);
+          #elif BOARD_MODEL == BOARD_WIO_L1
+            disp_mode = DISP_MODE_LANDSCAPE;
+            display.setRotation(0);
           #elif BOARD_MODEL == BOARD_HELTEC32_V2
             disp_mode = DISP_MODE_PORTRAIT;
             display.setRotation(1);

--- a/Display.h
+++ b/Display.h
@@ -283,6 +283,7 @@ void update_area_positions() {
 uint8_t display_contrast = 0x00;
 #if BOARD_MODEL == BOARD_TBEAM_S_V1 || BOARD_MODEL == BOARD_WIO_L1
   void set_contrast(Adafruit_SH1106G *display, uint8_t value) {
+    display->setContrast(value);
   }
 #elif BOARD_MODEL == BOARD_HELTEC_T114
   void set_contrast(ST7789Spi *display, uint8_t value) { }

--- a/Makefile
+++ b/Makefile
@@ -278,9 +278,9 @@ upload-heltec_t114:
 
 upload-wio_l1:
 	adafruit-nrfutil dfu genpkg --dev-type 0x0052 --sd-req 0x0123 --application build/adafruit.nrf52.wio_tracker_l1/RNode_Firmware_CE.ino.hex /tmp/rnode_wio_l1_dfu.zip
-	adafruit-nrfutil dfu serial --package /tmp/rnode_wio_l1_dfu.zip -p /dev/cu.usbmodem1101 -b 115200
+	adafruit-nrfutil dfu serial --package /tmp/rnode_wio_l1_dfu.zip -p $(or $(port), /dev/ttyACM0) -b 115200
 	@sleep 6
-	-rnodeconf /dev/cu.usbmodem1101 --firmware-hash $$(./partition_hashes from_device /dev/cu.usbmodem1101)
+	-rnodeconf $(or $(port), /dev/ttyACM0) --firmware-hash $$(./partition_hashes from_device $(or $(port), /dev/ttyACM0))
 
 upload-techo:
 	arduino-cli upload -p /dev/ttyACM0 --fqbn adafruit:nrf52:pca10056

--- a/Makefile
+++ b/Makefile
@@ -152,6 +152,9 @@ firmware-rak4631_sx1280:
 firmware-opencom-xl:
 	arduino-cli compile --fqbn rakwireless:nrf52:WisCoreRAK4631Board $(COMMON_BUILD_FLAGS) --build-property "compiler.cpp.extra_flags=\"-DBOARD_MODEL=0x52\" \"-DBOARD_VARIANT=0x21\""
 
+firmware-wio_l1:
+	arduino-cli compile --log --fqbn adafruit:nrf52:wio_tracker_l1 -e --build-property "build.partitions=no_ota" --build-property "upload.maximum_size=2097152" --build-property "build.sd_name=s140" --build-property "build.sd_version=7.3.0" --build-property "compiler.cpp.extra_flags=\"-DBOARD_MODEL=0x53\"" --build-property "build.sd_fwid=0x0123"
+
 firmware-heltec_t114:
 	arduino-cli compile --log --fqbn Heltec_nRF52:Heltec_nRF52:HT-n5262 -e --build-property "build.partitions=no_ota" --build-property "upload.maximum_size=2097152" --build-property "compiler.cpp.extra_flags=\"-DBOARD_MODEL=0x3C\""
 
@@ -272,6 +275,12 @@ upload-heltec_t114:
 	arduino-cli upload -p /dev/ttyACM0 --fqbn Heltec_nRF52:Heltec_nRF52:HT-n5262
 	@sleep 1
 	rnodeconf /dev/ttyACM0 --firmware-hash $$(./partition_hashes from_device /dev/ttyACM0)
+
+upload-wio_l1:
+	adafruit-nrfutil dfu genpkg --dev-type 0x0052 --sd-req 0x0123 --application build/adafruit.nrf52.wio_tracker_l1/RNode_Firmware_CE.ino.hex /tmp/rnode_wio_l1_dfu.zip
+	adafruit-nrfutil dfu serial --package /tmp/rnode_wio_l1_dfu.zip -p /dev/cu.usbmodem1101 -b 115200
+	@sleep 6
+	-rnodeconf /dev/cu.usbmodem1101 --firmware-hash $$(./partition_hashes from_device /dev/cu.usbmodem1101)
 
 upload-techo:
 	arduino-cli upload -p /dev/ttyACM0 --fqbn adafruit:nrf52:pca10056
@@ -521,6 +530,12 @@ release-opencom-xl:
 	arduino-cli compile --fqbn rakwireless:nrf52:WisCoreRAK4631Board $(COMMON_BUILD_FLAGS) --build-property "compiler.cpp.extra_flags=\"-DBOARD_MODEL=0x52\" \"-DBOARD_VARIANT=0x21\""
 	cp build/rakwireless.nrf52.WisCoreRAK4631Board/RNode_Firmware_CE.ino.hex build/rnode_firmware_opencom_xl.hex
 	adafruit-nrfutil dfu genpkg --dev-type 0x0052 --application build/rnode_firmware_opencom_xl.hex Release/rnode_firmware_opencom_xl.zip
+	rm -r build
+
+release-wio_l1:
+	arduino-cli compile --fqbn adafruit:nrf52:wio_tracker_l1 $(COMMON_BUILD_FLAGS) --build-property "build.sd_name=s140" --build-property "build.sd_version=7.3.0" --build-property "build.sd_fwid=0x0123" --build-property "compiler.cpp.extra_flags=\"-DBOARD_MODEL=0x53\""
+	cp build/adafruit.nrf52.wio_tracker_l1/RNode_Firmware_CE.ino.hex build/rnode_firmware_wio_l1.hex
+	adafruit-nrfutil dfu genpkg --dev-type 0x0052 --application build/rnode_firmware_wio_l1.hex Release/rnode_firmware_wio_l1.zip
 	rm -r build
 
 release-heltec_t114:

--- a/Power.h
+++ b/Power.h
@@ -148,6 +148,22 @@
   bool bat_voltage_dropping = false;
   float bat_delay_v = 0;
   float bat_state_change_v = 0;
+#elif BOARD_MODEL == BOARD_WIO_L1
+  #define BAT_V_MIN       3.15
+  #define BAT_V_MAX       4.165
+  #define BAT_V_CHG       4.48
+  #define BAT_V_FLOAT     4.13
+  #define BAT_SAMPLES     7
+  const uint8_t pin_vbat = 16;
+  float bat_p_samples[BAT_SAMPLES];
+  float bat_v_samples[BAT_SAMPLES];
+  uint8_t bat_samples_count = 0;
+  int bat_discharging_samples = 0;
+  int bat_charging_samples = 0;
+  int bat_charged_samples = 0;
+  bool bat_voltage_dropping = false;
+  float bat_delay_v = 0;
+  float bat_state_change_v = 0;
 #elif BOARD_MODEL == BOARD_TECHO
   #define BAT_V_MIN       3.15
   #define BAT_V_MAX       4.16
@@ -174,7 +190,7 @@ uint8_t pmu_rc = 0;
 void kiss_indicate_battery();
 
 void measure_battery() {
-  #if BOARD_MODEL == BOARD_RNODE_NG_21 || BOARD_MODEL == BOARD_LORA32_V2_1 || BOARD_MODEL == BOARD_HELTEC32_V3 || BOARD_MODEL == BOARD_TDECK || BOARD_MODEL == BOARD_T3S3 || BOARD_MODEL == BOARD_HELTEC_T114 || BOARD_MODEL == BOARD_TECHO
+  #if BOARD_MODEL == BOARD_RNODE_NG_21 || BOARD_MODEL == BOARD_LORA32_V2_1 || BOARD_MODEL == BOARD_HELTEC32_V3 || BOARD_MODEL == BOARD_TDECK || BOARD_MODEL == BOARD_T3S3 || BOARD_MODEL == BOARD_HELTEC_T114 || BOARD_MODEL == BOARD_TECHO || BOARD_MODEL == BOARD_WIO_L1
     battery_installed = true;
     battery_indeterminate = true;
 
@@ -186,6 +202,9 @@ void measure_battery() {
       float battery_measurement = (float)(analogRead(pin_vbat)) * 0.017165;
     #elif BOARD_MODEL == BOARD_TECHO
       float battery_measurement = (float)(analogRead(pin_vbat)) * 0.007067;
+    #elif BOARD_MODEL == BOARD_WIO_L1
+      // 12-bit ADC, AREF=3.6V, 2.0x voltage divider
+      float battery_measurement = (float)(analogRead(pin_vbat)) * 2.0 * 3.6 / 4096.0;
     #else
       float battery_measurement = (float)(analogRead(pin_vbat)) / 4095.0*7.26;
     #endif
@@ -444,6 +463,12 @@ bool init_pmu() {
   #elif BOARD_MODEL == BOARD_HELTEC_T114
     pinMode(pin_ctrl,OUTPUT);
     digitalWrite(pin_ctrl, HIGH);
+    return true;
+  #elif BOARD_MODEL == BOARD_WIO_L1
+    analogReadResolution(12);
+    pinMode(30, OUTPUT);      // VBAT_ENABLE
+    digitalWrite(30, HIGH);
+    pinMode(pin_vbat, INPUT);
     return true;
   #elif BOARD_MODEL == BOARD_TBEAM
     Wire.begin(I2C_SDA, I2C_SCL);

--- a/RNode_Firmware_CE.ino
+++ b/RNode_Firmware_CE.ino
@@ -46,9 +46,20 @@
     SPIClass interface_spi[1] = {
             // SX1262
             SPIClass(
-                NRF_SPIM1, 
-                interface_pins[0][3], 
-                interface_pins[0][1], 
+                NRF_SPIM1,
+                interface_pins[0][3],
+                interface_pins[0][1],
+                interface_pins[0][2]
+               )
+      };
+  #elif BOARD_MODEL == BOARD_WIO_L1
+    #define INTERFACE_SPI
+    SPIClass interface_spi[1] = {
+            // SX1262
+            SPIClass(
+                NRF_SPIM2,
+                interface_pins[0][3],
+                interface_pins[0][1],
                 interface_pins[0][2]
                )
       };
@@ -137,6 +148,14 @@ void setup() {
       pinMode(PIN_VEXT_EN, OUTPUT);
       digitalWrite(PIN_VEXT_EN, HIGH);
       delay(100);
+    #elif BOARD_MODEL == BOARD_WIO_L1
+      pinMode(pin_btn_usr1, INPUT_PULLUP);
+      delay(50);
+      if (digitalRead(pin_btn_usr1) == LOW) {
+        InternalFS.begin();
+        InternalFS.format();
+        NVIC_SystemReset();
+      }
     #endif
 
 
@@ -179,7 +198,7 @@ void setup() {
     boot_seq();
   #endif
 
-  #if BOARD_MODEL != BOARD_RAK4631 && BOARD_MODEL != BOARD_HELTEC_T114 && BOARD_MODEL != BOARD_TECHO && BOARD_MODEL != BOARD_T3S3 && BOARD_MODEL != BOARD_TBEAM_S_V1 && BOARD_MODEL != BOARD_OPENCOM_XL
+  #if BOARD_MODEL != BOARD_RAK4631 && BOARD_MODEL != BOARD_HELTEC_T114 && BOARD_MODEL != BOARD_TECHO && BOARD_MODEL != BOARD_T3S3 && BOARD_MODEL != BOARD_TBEAM_S_V1 && BOARD_MODEL != BOARD_OPENCOM_XL && BOARD_MODEL != BOARD_WIO_L1
   // Some boards need to wait until the hardware UART is set up before booting
   // the full firmware. In the case of the RAK4631/TECHO, the line below will wait
   // until a serial connection is actually established with a master. Thus, it
@@ -1580,7 +1599,7 @@ void loop() {
   process_serial();
 
   #if HAS_DISPLAY
-    #if DISPLAY == OLED || DISPLAY == TFT || DISPLAY == ADAFRUIT_TFT
+    #if DISPLAY == OLED || DISPLAY == MONO_OLED || DISPLAY == TFT || DISPLAY == ADAFRUIT_TFT
     if (disp_ready) update_display();
     #elif DISPLAY == EINK_BW || DISPLAY == EINK_3C
     // Display refreshes take so long on e-paper displays that they can disrupt

--- a/RNode_Firmware_CE.ino
+++ b/RNode_Firmware_CE.ino
@@ -148,14 +148,6 @@ void setup() {
       pinMode(PIN_VEXT_EN, OUTPUT);
       digitalWrite(PIN_VEXT_EN, HIGH);
       delay(100);
-    #elif BOARD_MODEL == BOARD_WIO_L1
-      pinMode(pin_btn_usr1, INPUT_PULLUP);
-      delay(50);
-      if (digitalRead(pin_btn_usr1) == LOW) {
-        InternalFS.begin();
-        InternalFS.format();
-        NVIC_SystemReset();
-      }
     #endif
 
 

--- a/Radio.cpp
+++ b/Radio.cpp
@@ -711,6 +711,8 @@ void sx126x::enableTCXO() {
       uint8_t buf[4] = {MODE_TCXO_1_8V_6X, 0x00, 0x00, 0xFF};
     #elif BOARD_MODEL == BOARD_HELTEC_T114
       uint8_t buf[4] = {MODE_TCXO_1_8V_6X, 0x00, 0x00, 0xFF};
+    #elif BOARD_MODEL == BOARD_WIO_L1
+      uint8_t buf[4] = {MODE_TCXO_1_8V_6X, 0x00, 0x00, 0xFF};
     #elif BOARD_MODEL == BOARD_E22_ESP32
       uint8_t buf[4] = {MODE_TCXO_1_8V_6X, 0x00, 0x00, 0xFF};
     #else

--- a/Utilities.h
+++ b/Utilities.h
@@ -361,6 +361,13 @@ uint8_t boot_vector = 0x00;
 		void led_tx_off() { digitalWrite(pin_led_tx, LED_OFF); }
 		void led_id_on()  { }
 		void led_id_off() { }
+  #elif BOARD_MODEL == BOARD_WIO_L1
+    void led_rx_on()  { digitalWrite(pin_led_rx, HIGH); }
+    void led_rx_off() { digitalWrite(pin_led_rx, LOW); }
+    void led_tx_on()  { digitalWrite(pin_led_tx, HIGH); }
+    void led_tx_off() { digitalWrite(pin_led_tx, LOW); }
+    void led_id_on()  { }
+    void led_id_off() { }
 	#endif
 #endif
 
@@ -368,6 +375,13 @@ void hard_reset(void) {
 	#if MCU_VARIANT == MCU_ESP32
 		ESP.restart();
 	#elif MCU_VARIANT == MCU_NRF52
+    #if !HAS_EEPROM
+      if (file) {
+        file.flush();
+        file.close();
+      }
+      InternalFS.end();
+    #endif
     NVIC_SystemReset();
 	#endif
 }
@@ -1291,6 +1305,8 @@ void setTXPower(RadioInterface* radio, int txp) {
     if (model == MODEL_E3) radio->setTxPower(txp, PA_OUTPUT_PA_BOOST_PIN);
     if (model == MODEL_E8) radio->setTxPower(txp, PA_OUTPUT_PA_BOOST_PIN);
 
+    if (model == MODEL_19) radio->setTxPower(txp, PA_OUTPUT_RFO_PIN);
+
     if (model == MODEL_FE) radio->setTxPower(txp, PA_OUTPUT_PA_BOOST_PIN);
     if (model == MODEL_FF) radio->setTxPower(txp, PA_OUTPUT_RFO_PIN);
 }
@@ -1378,6 +1394,7 @@ void promisc_disable() {
         return false;
       }
     } else {
+      file_exists = true;
       file.close();
       file.open(EEPROM_FILE, FILE_O_WRITE);
       return true;
@@ -1517,7 +1534,7 @@ bool eeprom_product_valid() {
 	#if PLATFORM == PLATFORM_ESP32
 	if (rval == PRODUCT_RNODE || rval == BOARD_RNODE_NG_20 || rval == BOARD_RNODE_NG_21 || rval == PRODUCT_HMBRW || rval == PRODUCT_TBEAM || rval == PRODUCT_T32_10 || rval == PRODUCT_T32_20 || rval == PRODUCT_T32_21 || rval == PRODUCT_H32_V2 || rval == PRODUCT_H32_V3 || rval == PRODUCT_TDECK_V1 || rval == PRODUCT_TBEAM_S_V1 || rval == PRODUCT_H_W_PAPER || rval == PRODUCT_XIAO_S3) {
 	#elif PLATFORM == PLATFORM_NRF52
-	if (rval == PRODUCT_RAK4631 || rval == PRODUCT_HELTEC_T114 || rval == PRODUCT_OPENCOM_XL || rval == PRODUCT_TECHO || rval == PRODUCT_HMBRW) {
+	if (rval == PRODUCT_RAK4631 || rval == PRODUCT_HELTEC_T114 || rval == PRODUCT_OPENCOM_XL || rval == PRODUCT_TECHO || rval == PRODUCT_HMBRW || rval == PRODUCT_WIO_L1) {
 	#else
 	if (false) {
 	#endif
@@ -1571,6 +1588,8 @@ bool eeprom_model_valid() {
     if (model == MODEL_11 || model == MODEL_12 || model == MODEL_13 || model == MODEL_14) {
     #elif BOARD_MODEL == BOARD_OPENCOM_XL
     if (model == MODEL_21) {
+    #elif BOARD_MODEL == BOARD_WIO_L1
+    if (model == MODEL_19) {
 	#elif BOARD_MODEL == BOARD_HUZZAH32
 	if (model == MODEL_FF) {
 	#elif BOARD_MODEL == BOARD_E22_ESP32

--- a/Utilities.h
+++ b/Utilities.h
@@ -375,13 +375,6 @@ void hard_reset(void) {
 	#if MCU_VARIANT == MCU_ESP32
 		ESP.restart();
 	#elif MCU_VARIANT == MCU_NRF52
-    #if !HAS_EEPROM
-      if (file) {
-        file.flush();
-        file.close();
-      }
-      InternalFS.end();
-    #endif
     NVIC_SystemReset();
 	#endif
 }
@@ -1394,7 +1387,6 @@ void promisc_disable() {
         return false;
       }
     } else {
-      file_exists = true;
       file.close();
       file.open(EEPROM_FILE, FILE_O_WRITE);
       return true;


### PR DESCRIPTION
Adds support for Wio Tracker L1 (the base variant with OLED display).

I couldn't find the pin mapping anywhere on Seeed's resources 🤷, so I pulled it from the [MeshCore firmware source](https://github.com/meshcore-dev/MeshCore/blob/main/variants/wio-tracker-l1/variant.h) (MIT licensed). The thing has a joystick and a button, but I haven't done anything fancy for them.

I've tested this on my device (Wio Tracker L1 Pro - includes GPS on top of the board itself) over a long session and it works well.

If it is of any help with future work, I have this changeset also rebased on Mark's repo.