### PR TITLE
feat: add support for the Seeed Wio Tracker L1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,6 @@ Release/*.json
 Console/build
 build/*
 .vscode
+.arduino-data
+.direnv/
+Release/*.uf2

--- a/Bluetooth.h
+++ b/Bluetooth.h
@@ -588,6 +588,7 @@ char bt_devname[11];
   void bt_enable_pairing() {
     // Serial.println("BT enable pairing");
     if (bt_state == BT_STATE_OFF) bt_start();
+    buzzer_pairing_signal();
 
     uint32_t pin = bt_get_passkey();
     char pin_char[6];

--- a/Boards.h
+++ b/Boards.h
@@ -123,6 +123,10 @@
   #define MODEL_16            0x16 // T-Echo 433 MHz
   #define MODEL_17            0x17 // T-Echo 868/915 MHz
 
+  #define PRODUCT_WIO_L1      0x18 // Seeed Wio Tracker L1 series (L1, L1 Pro)
+  #define BOARD_WIO_L1        0x53
+  #define MODEL_19            0x19 // Wio Tracker L1, 862-930 MHz
+
   #define PRODUCT_HMBRW       0xF0
   #define BOARD_HMBRW         0x32
   #define BOARD_HUZZAH32      0x34
@@ -158,6 +162,8 @@
   #define HAS_EEPROM false
   #define HAS_INPUT false
   #define HAS_SLEEP false
+  #define HAS_JOYSTICK false
+  #define HAS_BUZZER false
   #define PIN_DISP_SLEEP -1
   #define VALIDATE_FIRMWARE true
 
@@ -1388,8 +1394,78 @@
       #define HAS_GPS true
       #define GPS_BAUD_RATE 9600
       #define PIN_GPS_RX 37
-      #define PIN_GPS_TX 39 
+      #define PIN_GPS_TX 39
       #endif
+    #elif BOARD_MODEL == BOARD_WIO_L1
+      // Seeed Wio Tracker L1 (nRF52840 + Wio-SX1262), built against the
+      // generic adafruit:nrf52:pca10056 variant, so all pins below are raw
+      // nRF GPIO numbers (port*32 + pin).
+      #define _PINNUM(port, pin) ((port)*32 + (pin))
+      #define HAS_EEPROM false
+      #define HAS_DISPLAY true
+      #define DISPLAY MONO_OLED
+      #define HAS_BLUETOOTH false
+      #define HAS_BLE true
+      #define HAS_CONSOLE false
+      #define HAS_PMU true
+      #define HAS_NP false
+      #define HAS_SD false
+      #define HAS_TCXO true
+      #define HAS_BUSY true
+      #define HAS_INPUT true
+      #define HAS_SLEEP true
+      #define HAS_JOYSTICK true
+      #define HAS_BUZZER true
+      #define EEPROM_SIZE 296
+      #define EEPROM_OFFSET EEPROM_SIZE-EEPROM_RESERVED
+      #define BLE_MANUFACTURER "Seeed Studio"
+      #define BLE_MODEL "Wio Tracker L1"
+
+      #define INTERFACE_COUNT 1
+
+      const uint8_t interfaces[INTERFACE_COUNT] = {SX1262};
+      const bool interface_cfg[INTERFACE_COUNT][3] = {
+                    // SX1262
+          {
+              false, // DEFAULT_SPI
+              true,  // HAS_TCXO
+              true   // DIO2_AS_RF_SWITCH
+          }
+      };
+      const int8_t interface_pins[INTERFACE_COUNT][10] = {
+                  // SX1262
+          {
+              _PINNUM(1, 14), // pin_ss
+              _PINNUM(0, 30), // pin_sclk
+              _PINNUM(0, 28), // pin_mosi
+              _PINNUM(0, 3),  // pin_miso
+              _PINNUM(1, 10), // pin_busy
+              _PINNUM(0, 7),  // pin_dio
+              _PINNUM(1, 7),  // pin_reset
+              -1,             // pin_txen
+              _PINNUM(1, 8),  // pin_rxen
+              -1              // pin_tcxo_enable
+          }
+      };
+
+      const int pin_btn_usr1 = _PINNUM(0, 8); // Menu key
+
+      // 4-way joystick with center press
+      const int pin_joy_up    = _PINNUM(1, 4);
+      const int pin_joy_down  = _PINNUM(0, 12);
+      const int pin_joy_left  = _PINNUM(0, 11);
+      const int pin_joy_right = _PINNUM(1, 3);
+      const int pin_joy_press = _PINNUM(1, 5);
+
+      // Passive buzzer, PWM
+      const int pin_buzzer = _PINNUM(1, 0);
+
+      // L76K GNSS standby control (the GNSS is unused by this firmware)
+      const int pin_gnss_standby = _PINNUM(1, 9);
+
+      // Single user LED (yellow)
+      const int pin_led_rx = _PINNUM(1, 1);
+      const int pin_led_tx = _PINNUM(1, 1);
     #else
       #error An unsupported nRF board was selected. Cannot compile RNode firmware.
     #endif

--- a/Buzzer.h
+++ b/Buzzer.h
@@ -1,0 +1,42 @@
+// Copyright (C) 2026, Emanuele Calo
+
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+#ifndef BUZZER_H
+  #define BUZZER_H
+
+  #if HAS_BUZZER
+    // Build with -DBUZZER_ENABLED=false for a silent firmware.
+    #ifndef BUZZER_ENABLED
+      #define BUZZER_ENABLED true
+    #endif
+
+    void buzzer_init() {
+      pinMode(pin_buzzer, OUTPUT);
+      noTone(pin_buzzer);
+    }
+
+    void buzzer_beep(unsigned int freq, unsigned long duration_ms) {
+      if (BUZZER_ENABLED) { tone(pin_buzzer, freq, duration_ms); }
+    }
+
+    // 2.7 kHz is the rated resonant frequency of the onboard passive buzzer
+    void buzzer_boot_signal()    { buzzer_beep(2700, 60); }
+    void buzzer_pairing_signal() { buzzer_beep(2200, 40); }
+  #else
+    void buzzer_init() {}
+    void buzzer_boot_signal() {}
+    void buzzer_pairing_signal() {}
+  #endif
+#endif

--- a/Display.h
+++ b/Display.h
@@ -125,6 +125,12 @@ void busyCallback(const void* p) { display_callback(); }
   #define SCL_OLED 18
   #define SDA_OLED 17
   #define DISP_CUSTOM_ADDR false
+#elif BOARD_MODEL == BOARD_WIO_L1
+  #define DISP_RST -1
+  #define DISP_ADDR 0x3D
+  #define SCL_OLED 5
+  #define SDA_OLED 6
+  #define DISP_CUSTOM_ADDR false
 #elif BOARD_MODEL == BOARD_H_W_PAPER
   #define DISP_W 250
   #define DISP_H 122
@@ -170,7 +176,7 @@ uint32_t last_epd_full_refresh = 0;
     Adafruit_SSD1306 display(DISP_W, DISP_H, &Wire, DISP_RST);
   #elif BOARD_MODEL == BOARD_TDECK
     Adafruit_ST7789 display = Adafruit_ST7789(DISPLAY_CS, DISPLAY_DC, -1);
-  #elif BOARD_MODEL == BOARD_TBEAM_S_V1
+  #elif BOARD_MODEL == BOARD_TBEAM_S_V1 || BOARD_MODEL == BOARD_WIO_L1
     Adafruit_SH1106G display = Adafruit_SH1106G(DISP_W, DISP_H, &Wire, -1);
   #elif BOARD_MODEL == BOARD_HELTEC_T114
     ST7789Spi display(&SPI1, DISPLAY_RST, DISPLAY_DC, DISPLAY_CS);
@@ -276,6 +282,10 @@ uint8_t display_contrast = 0x00;
 #if BOARD_MODEL == BOARD_TBEAM_S_V1
   void set_contrast(Adafruit_SH1106G *display, uint8_t value) {
   }
+#elif BOARD_MODEL == BOARD_WIO_L1
+  void set_contrast(Adafruit_SH1106G *display, uint8_t value) {
+    display->setContrast(value);
+  }
 #elif BOARD_MODEL == BOARD_HELTEC_T114
   void set_contrast(ST7789Spi *display, uint8_t value) { }
 #elif BOARD_MODEL == BOARD_TECHO
@@ -377,6 +387,10 @@ bool display_init() {
       #endif
     #elif BOARD_MODEL == BOARD_TBEAM_S_V1
       Wire.begin(SDA_OLED, SCL_OLED);
+    #elif BOARD_MODEL == BOARD_WIO_L1
+      // nRF52: I2C pins are set on the TWIM peripheral, not passed to begin()
+      Wire.setPins(SDA_OLED, SCL_OLED);
+      Wire.begin();
     #elif BOARD_MODEL == BOARD_XIAO_S3
       Wire.begin(SDA_OLED, SCL_OLED);
     #endif
@@ -431,7 +445,7 @@ bool display_init() {
     // set white as default pixel colour for Heltec T114
     display.setRGB(COLOR565(0xFF, 0xFF, 0xFF));
     if (false) {
-    #elif BOARD_MODEL == BOARD_TBEAM_S_V1
+    #elif BOARD_MODEL == BOARD_TBEAM_S_V1 || BOARD_MODEL == BOARD_WIO_L1
     if (!display.begin(display_address, true)) {
     #else
     if (!display.begin(SSD1306_SWITCHCAPVCC, display_address)) {
@@ -481,6 +495,9 @@ bool display_init() {
           #elif BOARD_MODEL == BOARD_TECHO
             disp_mode = DISP_MODE_LANDSCAPE;
             display.setRotation(3);
+          #elif BOARD_MODEL == BOARD_WIO_L1
+            disp_mode = DISP_MODE_LANDSCAPE;
+            display.setRotation(0);
           #elif BOARD_MODEL == BOARD_HELTEC32_V3
             disp_mode = DISP_MODE_PORTRAIT;
             display.setRotation(1);

--- a/Documentation/BUILDING.md
+++ b/Documentation/BUILDING.md
@@ -35,6 +35,7 @@ Next, you need to find the name of the target for your board. Please reference t
 | LilyGO LoRa32 v2.1 | `lora32_v21` |
 | Heltec LoRa32 v2 | `heltec32_v2` |
 | Heltec LoRa32 v3 | `heltec32_v3` | 
+| Seeed Wio Tracker L1 | `wio_l1` |
 | Homebrew ESP32 boards | `genericesp32` |
 
 After you've ascertained the target for the board simply run the following to compile for the board:
@@ -68,6 +69,7 @@ After flashing a custom board, you will also need to provision the EEPROM before
 ```
 0x11: [430000000, 510000000, 22, "430 - 510 MHz", "rnode_firmware_rak4631.zip", "SX1262"],
 0x12: [779000000, 928000000, 22, "779 - 928 MHz", "rnode_firmware_rak4631.zip", "SX1262"],
+0x19: [862000000, 930000000, 22, "862 - 930 MHz", "rnode_firmware_wio_l1.zip", "SX1262"],
 0xA4: [410000000, 525000000, 14, "410 - 525 MHz", "rnode_firmware.hex", "SX1278"],
 0xA9: [820000000, 1020000000, 17, "820 - 1020 MHz", "rnode_firmware.hex", "SX1276"],
 0xA1: [410000000, 525000000, 22, "410 - 525 MHz", "rnode_firmware_t3s3.zip", "SX1268"],

--- a/Input.h
+++ b/Input.h
@@ -40,8 +40,61 @@
   // Forward declaration
   void button_event(uint8_t event, unsigned long duration);
 
+  #if HAS_JOYSTICK
+    int joy_press_state = RELEASED;
+    int joy_press_debounce_state = RELEASED;
+    unsigned long joy_press_debounce_last = 0;
+    unsigned long joy_press_down_last = 0;
+    unsigned long joy_dir_last = 0;
+    const unsigned long joy_dir_min_interval = 150;
+
+    // Forward declaration
+    void joystick_direction_event();
+
+    void joystick_init() {
+      pinMode(pin_joy_press, INPUT_PULLUP);
+      pinMode(pin_joy_up, INPUT_PULLUP);
+      pinMode(pin_joy_down, INPUT_PULLUP);
+      pinMode(pin_joy_left, INPUT_PULLUP);
+      pinMode(pin_joy_right, INPUT_PULLUP);
+    }
+
+    // Center press feeds the normal button event pipeline, directions
+    // only fire joystick_direction_event (rate limited, no debouncer).
+    void joystick_read() {
+      int reading = digitalRead(pin_joy_press);
+      if (reading != joy_press_debounce_state) {
+        joy_press_debounce_last = millis();
+        joy_press_debounce_state = reading;
+      }
+
+      if ((millis() - joy_press_debounce_last) > button_debounce_delay) {
+        if (reading != joy_press_state) {
+          int previous_state = joy_press_state;
+          joy_press_state = reading;
+          if (previous_state == PRESSED && joy_press_state == RELEASED) {
+            button_event(EVENT_BUTTON_CLICK, millis()-joy_press_down_last);
+          } else if (previous_state == RELEASED && joy_press_state == PRESSED) {
+            joy_press_down_last = millis();
+          }
+        }
+      }
+
+      if ((millis() - joy_dir_last) > joy_dir_min_interval) {
+        if (digitalRead(pin_joy_up) == PRESSED || digitalRead(pin_joy_down) == PRESSED ||
+            digitalRead(pin_joy_left) == PRESSED || digitalRead(pin_joy_right) == PRESSED) {
+          joy_dir_last = millis();
+          joystick_direction_event();
+        }
+      }
+    }
+  #endif
+
   void input_init() {
     pinMode(PIN_BUTTON, INPUT_PULLUP);
+    #if HAS_JOYSTICK
+      joystick_init();
+    #endif
   }
 
   void input_get_all_events() {
@@ -53,6 +106,10 @@
   }
 
   void input_read() {
+    #if HAS_JOYSTICK
+      joystick_read();
+    #endif
+
     int button_reading = digitalRead(PIN_BUTTON);
     if (button_reading != debounce_state) {
       button_debounce_last = millis();

--- a/Makefile
+++ b/Makefile
@@ -86,6 +86,11 @@ firmware-tbeam_sx1262: check_bt_buffers
 firmware-techo:
 	arduino-cli compile --fqbn adafruit:nrf52:pca10056 $(COMMON_BUILD_FLAGS) --build-property "compiler.cpp.extra_flags=\"-DBOARD_MODEL=0x44\""
 
+# The Wio Tracker L1 bootloader ships SoftDevice S140 v7.3.0, so the app is
+# linked with the v7 script from ./linker (the Adafruit core only bundles v6).
+firmware-wio_l1:
+	arduino-cli compile --fqbn adafruit:nrf52:pca10056 $(COMMON_BUILD_FLAGS) --build-property "build.sd_name=s140" --build-property "build.sd_version=7.3.0" --build-property "build.sd_fwid=0x0123" --build-property "build.ldscript=nrf52840_s140_v7.ld" --build-property "compiler.c.elf.extra_flags=-L$(CURDIR)/linker" --build-property "compiler.cpp.extra_flags=\"-DBOARD_MODEL=0x53\""
+
 firmware-t3s3:
 	arduino-cli compile --fqbn "esp32:esp32:esp32s3:CDCOnBoot=cdc" $(COMMON_BUILD_FLAGS) --build-property "compiler.cpp.extra_flags=\"-DBOARD_MODEL=0x42\" \"-DBOARD_VARIANT=0xAB\""
 
@@ -278,6 +283,12 @@ upload-techo:
 	@sleep 6
 	rnodeconf /dev/ttyACM0 --firmware-hash $$(./partition_hashes from_device /dev/ttyACM0)
 
+upload-wio_l1:
+	adafruit-nrfutil dfu genpkg --dev-type 0x0052 --sd-req 0x0123 --application build/adafruit.nrf52.pca10056/RNode_Firmware_CE.ino.hex build/rnode_wio_l1_dfu.zip
+	adafruit-nrfutil dfu serial --package build/rnode_wio_l1_dfu.zip -p $(or $(port), /dev/ttyACM0) -b 115200
+	@sleep 6
+	rnodeconf $(or $(port), /dev/ttyACM0) --firmware-hash $$(./partition_hashes from_device $(or $(port), /dev/ttyACM0))
+
 release:  console-site spiffs-image $(shell grep ^release- Makefile | cut -d: -f1)
 
 release-hashes:
@@ -429,6 +440,13 @@ release-techo:
 	arduino-cli compile --fqbn adafruit:nrf52:pca10056 $(COMMON_BUILD_FLAGS) --build-property "compiler.cpp.extra_flags=\"-DBOARD_MODEL=0x44\""
 	cp build/adafruit.nrf52.pca10056/RNode_Firmware_CE.ino.hex build/rnode_firmware_techo.hex
 	adafruit-nrfutil dfu genpkg --dev-type 0x0052 --application build/rnode_firmware_techo.hex Release/rnode_firmware_techo.zip
+	rm -r build
+
+release-wio_l1:
+	arduino-cli compile --fqbn adafruit:nrf52:pca10056 $(COMMON_BUILD_FLAGS) --build-property "build.sd_name=s140" --build-property "build.sd_version=7.3.0" --build-property "build.sd_fwid=0x0123" --build-property "build.ldscript=nrf52840_s140_v7.ld" --build-property "compiler.c.elf.extra_flags=-L$(CURDIR)/linker" --build-property "compiler.cpp.extra_flags=\"-DBOARD_MODEL=0x53\""
+	cp build/adafruit.nrf52.pca10056/RNode_Firmware_CE.ino.hex build/rnode_firmware_wio_l1.hex
+	adafruit-nrfutil dfu genpkg --dev-type 0x0052 --sd-req 0x0123 --application build/rnode_firmware_wio_l1.hex Release/rnode_firmware_wio_l1.zip
+	uf2conv build/rnode_firmware_wio_l1.hex -c -f 0xADA52840 -o Release/rnode_firmware_wio_l1.uf2
 	rm -r build
 
 release-t3s3:

--- a/Power.h
+++ b/Power.h
@@ -148,6 +148,23 @@
   bool bat_voltage_dropping = false;
   float bat_delay_v = 0;
   float bat_state_change_v = 0;
+#elif BOARD_MODEL == BOARD_WIO_L1
+  #define BAT_V_MIN       3.15
+  #define BAT_V_MAX       4.2
+  #define BAT_V_CHG       4.48
+  #define BAT_V_FLOAT     4.33
+  #define BAT_SAMPLES     7
+  const uint8_t pin_vbat = 31; // P0.31, AIN7
+  const uint8_t pin_ctrl = 4;  // P0.04, battery divider enable, active high
+  float bat_p_samples[BAT_SAMPLES];
+  float bat_v_samples[BAT_SAMPLES];
+  uint8_t bat_samples_count = 0;
+  int bat_discharging_samples = 0;
+  int bat_charging_samples = 0;
+  int bat_charged_samples = 0;
+  bool bat_voltage_dropping = false;
+  float bat_delay_v = 0;
+  float bat_state_change_v = 0;
 #elif BOARD_MODEL == BOARD_TECHO
   #define BAT_V_MIN       3.15
   #define BAT_V_MAX       4.16
@@ -174,7 +191,7 @@ uint8_t pmu_rc = 0;
 void kiss_indicate_battery();
 
 void measure_battery() {
-  #if BOARD_MODEL == BOARD_RNODE_NG_21 || BOARD_MODEL == BOARD_LORA32_V2_1 || BOARD_MODEL == BOARD_HELTEC32_V3 || BOARD_MODEL == BOARD_TDECK || BOARD_MODEL == BOARD_T3S3 || BOARD_MODEL == BOARD_HELTEC_T114 || BOARD_MODEL == BOARD_TECHO
+  #if BOARD_MODEL == BOARD_RNODE_NG_21 || BOARD_MODEL == BOARD_LORA32_V2_1 || BOARD_MODEL == BOARD_HELTEC32_V3 || BOARD_MODEL == BOARD_TDECK || BOARD_MODEL == BOARD_T3S3 || BOARD_MODEL == BOARD_HELTEC_T114 || BOARD_MODEL == BOARD_TECHO || BOARD_MODEL == BOARD_WIO_L1
     battery_installed = true;
     battery_indeterminate = true;
 
@@ -186,6 +203,9 @@ void measure_battery() {
       float battery_measurement = (float)(analogRead(pin_vbat)) * 0.017165;
     #elif BOARD_MODEL == BOARD_TECHO
       float battery_measurement = (float)(analogRead(pin_vbat)) * 0.007067;
+    #elif BOARD_MODEL == BOARD_WIO_L1
+      // 12-bit ADC, 3.6 V reference, 2.0x divider (1M/2M gated by P0.04)
+      float battery_measurement = (float)(analogRead(pin_vbat)) * 2.0 * 3.6 / 4096.0;
     #else
       float battery_measurement = (float)(analogRead(pin_vbat)) / 4095.0*7.26;
     #endif
@@ -444,6 +464,12 @@ bool init_pmu() {
   #elif BOARD_MODEL == BOARD_HELTEC_T114
     pinMode(pin_ctrl,OUTPUT);
     digitalWrite(pin_ctrl, HIGH);
+    return true;
+  #elif BOARD_MODEL == BOARD_WIO_L1
+    analogReadResolution(12);
+    pinMode(pin_ctrl, OUTPUT);
+    digitalWrite(pin_ctrl, HIGH);
+    pinMode(pin_vbat, INPUT);
     return true;
   #elif BOARD_MODEL == BOARD_TBEAM
     Wire.begin(I2C_SDA, I2C_SCL);

--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ You must have at least version `2.1.3` of `rnodeconf` installed to update your R
 | LilyGo T3S3 v1.0 | [Buy here](https://lilygo.cc/products/t3s3-v1-0) | SX1262 or SX1276 or SX1280 | ESP32-S3 |
 | LilyGo T-Echo | [Buy here](https://lilygo.cc/products/t-echo-lilygo) | SX1262 | nRF52 |
 | Heltec T114 | [Buy here](https://heltec.org/project/mesh-node-t114/) | SX1262 | nRF52 | 
+| Seeed Wio Tracker L1 | [Buy here](https://www.seeedstudio.com/Wio-Tracker-L1-p-6453.html) | SX1262 | nRF52 | L1, Lite and Pro variants |
 | Homebrew ESP32 boards | | Any supported | ESP32 | This can be any board with an Adafruit Feather (or generic) ESP32 chip |
 
 It's easy to create your own RNodes from one of the supported development boards and devices. If a device or board you want to use is not yet supported, you are welcome to [join the effort](Documentation/CONTRIBUTING.md) and help create a board definition and pin mapping for it!

--- a/RNode_Firmware_CE.ino
+++ b/RNode_Firmware_CE.ino
@@ -46,13 +46,28 @@
     SPIClass interface_spi[1] = {
             // SX1262
             SPIClass(
-                NRF_SPIM1, 
-                interface_pins[0][3], 
-                interface_pins[0][1], 
+                NRF_SPIM1,
+                interface_pins[0][3],
+                interface_pins[0][1],
+                interface_pins[0][2]
+               )
+      };
+  #elif BOARD_MODEL == BOARD_WIO_L1
+    #define INTERFACE_SPI
+    SPIClass interface_spi[1] = {
+            // SX1262
+            SPIClass(
+                NRF_SPIM2,
+                interface_pins[0][3],
+                interface_pins[0][1],
                 interface_pins[0][2]
                )
       };
   #endif
+#endif
+
+#if BOARD_MODEL == BOARD_WIO_L1
+  #include <Adafruit_TinyUSB.h>
 #endif
 
 #ifndef INTERFACE_SPI
@@ -179,7 +194,7 @@ void setup() {
     boot_seq();
   #endif
 
-  #if BOARD_MODEL != BOARD_RAK4631 && BOARD_MODEL != BOARD_HELTEC_T114 && BOARD_MODEL != BOARD_TECHO && BOARD_MODEL != BOARD_T3S3 && BOARD_MODEL != BOARD_TBEAM_S_V1 && BOARD_MODEL != BOARD_OPENCOM_XL
+  #if BOARD_MODEL != BOARD_RAK4631 && BOARD_MODEL != BOARD_HELTEC_T114 && BOARD_MODEL != BOARD_TECHO && BOARD_MODEL != BOARD_T3S3 && BOARD_MODEL != BOARD_TBEAM_S_V1 && BOARD_MODEL != BOARD_OPENCOM_XL && BOARD_MODEL != BOARD_WIO_L1
   // Some boards need to wait until the hardware UART is set up before booting
   // the full firmware. In the case of the RAK4631/TECHO, the line below will wait
   // until a serial connection is actually established with a master. Thus, it
@@ -190,6 +205,17 @@ void setup() {
   // Configure input and output pins
   #if HAS_INPUT
     input_init();
+  #endif
+
+  #if HAS_BUZZER
+    buzzer_init();
+  #endif
+
+  #if BOARD_MODEL == BOARD_WIO_L1
+    // This firmware does not use the L76K GNSS; hold it in standby to
+    // save power. LOW is the standby level.
+    pinMode(pin_gnss_standby, OUTPUT);
+    digitalWrite(pin_gnss_standby, LOW);
   #endif
 
   #if HAS_NP == false
@@ -312,6 +338,14 @@ void setup() {
     delay(100);
   #endif
 
+  #if BOARD_MODEL == BOARD_WIO_L1
+    // The SX1262 stays powered across MCU resets and may hold another
+    // firmware's sync word (factory Meshtastic), which the probe below
+    // would reject. Reset it to defaults before probing.
+    interface_obj[0]->reset();
+    delay(100);
+  #endif
+
     // Check installed transceiver chip(s) and probe boot parameters. If any of
     // the configured modems cannot be initialised, do not boot
     for (int i = 0; i < INTERFACE_COUNT; i++) {
@@ -387,6 +421,15 @@ void setup() {
       pmu_ready = init_pmu();
     #endif
 
+    #if BOARD_MODEL == BOARD_WIO_L1
+      // Starting the SoftDevice while USB enumeration is in flight can
+      // deadlock the boot on this board. Wait for the host to finish
+      // enumerating, with a timeout for battery-only operation.
+      { uint32_t usb_wait_started = millis();
+        while (!TinyUSBDevice.mounted() && millis()-usb_wait_started < 3000) { delay(10); }
+        delay(100); }
+    #endif
+
     #if HAS_BLUETOOTH || HAS_BLE == true
       bt_init();
       bt_init_ran = true;
@@ -423,6 +466,10 @@ void setup() {
 
   // Validate board health, EEPROM and config
   validate_status();
+
+  #if HAS_BUZZER
+    buzzer_boot_signal();
+  #endif
 }
 
 void lora_receive(RadioInterface* radio) {
@@ -1580,7 +1627,7 @@ void loop() {
   process_serial();
 
   #if HAS_DISPLAY
-    #if DISPLAY == OLED || DISPLAY == TFT || DISPLAY == ADAFRUIT_TFT
+    #if DISPLAY == OLED || DISPLAY == MONO_OLED || DISPLAY == TFT || DISPLAY == ADAFRUIT_TFT
     if (disp_ready) update_display();
     #elif DISPLAY == EINK_BW || DISPLAY == EINK_3C
     // Display refreshes take so long on e-paper displays that they can disrupt
@@ -1679,12 +1726,26 @@ void sleep_now() {
         analogWrite(PIN_VEXT_EN, 0);
         delay(100);
       #endif
+      #if BOARD_MODEL == BOARD_WIO_L1
+        // The OLED keeps its last frame from internal RAM through
+        // SYSTEMOFF; clear it so the panel draws no current.
+        display.clearDisplay();
+        display.display();
+      #endif
       sd_power_gpregret_set(0, 0x6d);
       nrf_gpio_cfg_sense_input(pin_btn_usr1, NRF_GPIO_PIN_PULLUP, NRF_GPIO_PIN_SENSE_LOW);
       NRF_POWER->SYSTEMOFF = 1;
     #endif
   #endif
 }
+
+#if HAS_JOYSTICK
+  void joystick_direction_event() {
+    #if HAS_DISPLAY
+      if (display_blanked) { display_unblank(); }
+    #endif
+  }
+#endif
 
 void button_event(uint8_t event, unsigned long duration) {
     if (display_blanked) {

--- a/Radio.cpp
+++ b/Radio.cpp
@@ -711,6 +711,8 @@ void sx126x::enableTCXO() {
       uint8_t buf[4] = {MODE_TCXO_1_8V_6X, 0x00, 0x00, 0xFF};
     #elif BOARD_MODEL == BOARD_HELTEC_T114
       uint8_t buf[4] = {MODE_TCXO_1_8V_6X, 0x00, 0x00, 0xFF};
+    #elif BOARD_MODEL == BOARD_WIO_L1
+      uint8_t buf[4] = {MODE_TCXO_1_8V_6X, 0x00, 0x00, 0xFF};
     #elif BOARD_MODEL == BOARD_E22_ESP32
       uint8_t buf[4] = {MODE_TCXO_1_8V_6X, 0x00, 0x00, 0xFF};
     #else

--- a/Utilities.h
+++ b/Utilities.h
@@ -49,6 +49,8 @@ uint8_t eeprom_read(uint32_t mapped_addr);
 	bool display_blanked = false;
 #endif
 
+#include "Buzzer.h"
+
 #if HAS_BLUETOOTH == true || HAS_BLE == true
 	void kiss_indicate_btpin();
   #include "Bluetooth.h"
@@ -359,6 +361,13 @@ uint8_t boot_vector = 0x00;
 		void led_rx_off() {	digitalWrite(pin_led_rx, LED_OFF); }
 		void led_tx_on()  { digitalWrite(pin_led_tx, LED_ON); }
 		void led_tx_off() { digitalWrite(pin_led_tx, LED_OFF); }
+		void led_id_on()  { }
+		void led_id_off() { }
+  #elif BOARD_MODEL == BOARD_WIO_L1
+		void led_rx_on()  { digitalWrite(pin_led_rx, HIGH); }
+		void led_rx_off() { digitalWrite(pin_led_rx, LOW); }
+		void led_tx_on()  { digitalWrite(pin_led_tx, HIGH); }
+		void led_tx_off() { digitalWrite(pin_led_tx, LOW); }
 		void led_id_on()  { }
 		void led_id_off() { }
 	#endif
@@ -1251,6 +1260,8 @@ void setTXPower(RadioInterface* radio, int txp) {
     if (model == MODEL_16) radio->setTxPower(txp, PA_OUTPUT_PA_BOOST_PIN);
     if (model == MODEL_17) radio->setTxPower(txp, PA_OUTPUT_PA_BOOST_PIN);
 
+    if (model == MODEL_19) radio->setTxPower(txp, PA_OUTPUT_PA_BOOST_PIN);
+
     if (model == MODEL_A1) radio->setTxPower(txp, PA_OUTPUT_PA_BOOST_PIN);
     if (model == MODEL_A2) radio->setTxPower(txp, PA_OUTPUT_PA_BOOST_PIN);
     if (model == MODEL_A3) radio->setTxPower(txp, PA_OUTPUT_RFO_PIN);
@@ -1517,7 +1528,7 @@ bool eeprom_product_valid() {
 	#if PLATFORM == PLATFORM_ESP32
 	if (rval == PRODUCT_RNODE || rval == BOARD_RNODE_NG_20 || rval == BOARD_RNODE_NG_21 || rval == PRODUCT_HMBRW || rval == PRODUCT_TBEAM || rval == PRODUCT_T32_10 || rval == PRODUCT_T32_20 || rval == PRODUCT_T32_21 || rval == PRODUCT_H32_V2 || rval == PRODUCT_H32_V3 || rval == PRODUCT_TDECK_V1 || rval == PRODUCT_TBEAM_S_V1 || rval == PRODUCT_H_W_PAPER || rval == PRODUCT_XIAO_S3) {
 	#elif PLATFORM == PLATFORM_NRF52
-	if (rval == PRODUCT_RAK4631 || rval == PRODUCT_HELTEC_T114 || rval == PRODUCT_OPENCOM_XL || rval == PRODUCT_TECHO || rval == PRODUCT_HMBRW) {
+	if (rval == PRODUCT_RAK4631 || rval == PRODUCT_HELTEC_T114 || rval == PRODUCT_OPENCOM_XL || rval == PRODUCT_TECHO || rval == PRODUCT_WIO_L1 || rval == PRODUCT_HMBRW) {
 	#else
 	if (false) {
 	#endif
@@ -1549,6 +1560,8 @@ bool eeprom_model_valid() {
 	if (model == MODEL_D4 || model == MODEL_D9) {
 	#elif BOARD_MODEL == BOARD_TECHO
 	if (model == MODEL_16 || model == MODEL_17) {
+	#elif BOARD_MODEL == BOARD_WIO_L1
+	if (model == MODEL_19) {
 	#elif BOARD_MODEL == BOARD_TBEAM_S_V1
 	if (model == MODEL_DB || model == MODEL_DC) {
 	#elif BOARD_MODEL == BOARD_XIAO_S3

--- a/linker/nrf52840_s140_v7.ld
+++ b/linker/nrf52840_s140_v7.ld
@@ -1,0 +1,38 @@
+/* Linker script to configure memory regions. */
+
+SEARCH_DIR(.)
+GROUP(-lgcc -lc -lnosys)
+
+MEMORY
+{
+  FLASH (rx)     : ORIGIN = 0x27000, LENGTH = 0xED000 - 0x27000
+
+  /* SRAM required by Softdevice depend on
+   * - Attribute Table Size (Number of Services and Characteristics)
+   * - Vendor UUID count
+   * - Max ATT MTU
+   * - Concurrent connection peripheral + central + secure links
+   * - Event Len, HVN queue, Write CMD queue
+   */ 
+  RAM (rwx) :  ORIGIN = 0x20006000, LENGTH = 0x20040000 - 0x20006000
+}
+
+SECTIONS
+{
+  . = ALIGN(4);
+  .svc_data :
+  {
+    PROVIDE(__start_svc_data = .);
+    KEEP(*(.svc_data))
+    PROVIDE(__stop_svc_data = .);
+  } > RAM
+  
+  .fs_data :
+  {
+    PROVIDE(__start_fs_data = .);
+    KEEP(*(.fs_data))
+    PROVIDE(__stop_fs_data = .);
+  } > RAM
+} INSERT AFTER .data;
+
+INCLUDE "nrf52_common.ld"


### PR DESCRIPTION
## What

Adds support for the Seeed Wio Tracker L1 series (nRF52840 + Wio-SX1262) as `BOARD_WIO_L1` (0x53), `PRODUCT_WIO_L1` (0x18), `MODEL_19` (862-930 MHz, the single hardware SKU).

Supported board features:

- SX1262 radio with TCXO (DIO3, 1.8 V) and DIO2 as RF switch
- SH1106 1.3" OLED at I2C 0x3D, landscape orientation, working contrast and display blanking
- Battery monitoring behind the P0.04 divider gate
- Menu button as user button; the joystick center press acts as a user button too, and joystick directions wake the display
- Passive buzzer feedback on boot and BLE pairing, can be silenced with `-DBUZZER_ENABLED=false`
- The L76K GNSS is held in standby since the firmware does not use it

## How it builds

Builds against the stock `adafruit:nrf52:pca10056` variant with raw GPIO numbers, like the T-Echo, so no custom BSP or variant files are needed. The board's stock bootloader ships SoftDevice S140 v7.3.0 while the Adafruit core only bundles the v6 linker script, so the app links with the v7 script shipped in `./linker`, selected via build properties, and the DFU package is generated with `--sd-req 0x0123`. `make release-wio_l1` also produces a UF2 image for drag and drop flashing through the stock UF2 bootloader.

## Boot fixes found on hardware

- The SX1262 keeps a previous firmware's sync word across MCU resets, and these boards ship with Meshtastic preinstalled, so the modem probe rejected the chip until a full power cycle. The radio is now reset before probing, generalizing the existing T3S3 workaround.
- Starting the SoftDevice while USB CDC enumeration is in flight can deadlock the boot on this board. `bt_init` now waits for `TinyUSBDevice.mounted()` with a 3 second timeout for battery-only operation.

## Relationship to #106

This PR builds on the work in #106 (board definition structure, display rotation and contrast handling) and on markqvist/RNode_Firmware#128 (original pin mapping and the SH1106 at 0x3D findings). The main differences from #106: it builds against the released Adafruit core (the `adafruit:nrf52:wio_tracker_l1` FQBN referenced there does not exist in BSP 1.7.0), pin numbers are mapped for the pca10056 variant, and it adds the boot fixes and the extra board features listed above.

## Test plan

Tested on two Wio Tracker L1 (SKU 114993648) devices: build, UF2 and serial DFU flashing, EEPROM provisioning with rnodeconf, OLED rendering and rotation, buzzer, joystick, BLE pairing, battery readout, and a bidirectional LXMF message exchange over LoRa at 869.525 MHz between the two boards, one connected over USB and one over BLE. T-Echo regression build verified.

## rnodeconf note

rnodeconf's product and model tables do not know 0x18/0x19 yet; the entries documented in `Documentation/BUILDING.md` still need to land in RNS for full rnodeconf support.
