### PR TITLE
feat(heltec-v4): port marks code and make it fit CE conventions

### DIFF
--- a/Boards.h
+++ b/Boards.h
@@ -239,15 +239,15 @@
 
       #if BOARD_VARIANT == MODEL_E4 || BOARD_VARIANT == MODEL_E9
       const uint8_t interfaces[INTERFACE_COUNT] = {SX1276};
-      const bool interface_cfg[INTERFACE_COUNT][3] = { 
+      const bool interface_cfg[INTERFACE_COUNT][3] = {
                     // SX127X
           {
               true, // DEFAULT_SPI
               false, // HAS_TCXO
               false  // DIO2_AS_RF_SWITCH
-          }, 
+          },
       };
-      const int8_t interface_pins[INTERFACE_COUNT][10] = { 
+      const int8_t interface_pins[INTERFACE_COUNT][10] = {
                   // SX127X
           {
               18, // pin_ss
@@ -264,17 +264,17 @@
       };
 
       #elif BOARD_VARIANT == MODEL_E3 || BOARD_VARIANT == MODEL_E8
-      #define OCP_TUNED 0x38
+      #define OCP_TUNED 0x18
       const uint8_t interfaces[INTERFACE_COUNT] = {SX1262};
-      const bool interface_cfg[INTERFACE_COUNT][3] = { 
+      const bool interface_cfg[INTERFACE_COUNT][3] = {
                     // SX1262
           {
               true, // DEFAULT_SPI
               true, // HAS_TCXO
               true  // DIO2_AS_RF_SWITCH
-          }, 
+          },
       };
-      const int8_t interface_pins[INTERFACE_COUNT][10] = { 
+      const int8_t interface_pins[INTERFACE_COUNT][10] = {
                   // SX1262
           {
               18, // pin_ss
@@ -545,7 +545,7 @@
       #define PIN_WAKEUP GPIO_NUM_0
       #define WAKEUP_LEVEL 0
       #define INTERFACE_COUNT 1
-      #define OCP_TUNED 0x38
+      #define OCP_TUNED 0x18
 
       const int pin_btn_usr1 = 0;
 
@@ -986,7 +986,7 @@
 
     #elif BOARD_MODEL == BOARD_TBEAM_S_V1
       #define IS_ESP32S3 true
-      #define OCP_TUNED 0x38
+      #define OCP_TUNED 0x18
 
       #define HAS_DISPLAY true
       #define DISPLAY MONO_OLED
@@ -1475,7 +1475,7 @@
   // Default OCP value if not specified
   // in board configuration
   #ifndef OCP_TUNED
-    #define OCP_TUNED 0x38
+    #define OCP_TUNED 0x18
   #endif
 
   #ifndef NP_M

--- a/Boards.h
+++ b/Boards.h
@@ -678,6 +678,7 @@
       #define DIO2_AS_RF_SWITCH true
 
       #define LORA_LNA_GAIN  17
+      #define LORA_LNA_GVT   12
       #define LORA_PA_GC1109 true
       #define LORA_PA_PWR_EN  7
       #define LORA_PA_CSD     2

--- a/Boards.h
+++ b/Boards.h
@@ -254,15 +254,15 @@
 
       #if BOARD_VARIANT == MODEL_E4 || BOARD_VARIANT == MODEL_E9
       const uint8_t interfaces[INTERFACE_COUNT] = {SX1276};
-      const bool interface_cfg[INTERFACE_COUNT][3] = {
+      const bool interface_cfg[INTERFACE_COUNT][3] = { 
                     // SX127X
           {
               true, // DEFAULT_SPI
               false, // HAS_TCXO
               false  // DIO2_AS_RF_SWITCH
-          },
+          }, 
       };
-      const int8_t interface_pins[INTERFACE_COUNT][10] = {
+      const int8_t interface_pins[INTERFACE_COUNT][10] = { 
                   // SX127X
           {
               18, // pin_ss
@@ -281,15 +281,15 @@
       #elif BOARD_VARIANT == MODEL_E3 || BOARD_VARIANT == MODEL_E8
       #define OCP_TUNED 0x28
       const uint8_t interfaces[INTERFACE_COUNT] = {SX1262};
-      const bool interface_cfg[INTERFACE_COUNT][3] = {
+      const bool interface_cfg[INTERFACE_COUNT][3] = { 
                     // SX1262
           {
               true, // DEFAULT_SPI
               true, // HAS_TCXO
               true  // DIO2_AS_RF_SWITCH
-          },
+          }, 
       };
-      const int8_t interface_pins[INTERFACE_COUNT][10] = {
+      const int8_t interface_pins[INTERFACE_COUNT][10] = { 
                   // SX1262
           {
               18, // pin_ss

--- a/Boards.h
+++ b/Boards.h
@@ -153,6 +153,20 @@
       #error "The firmware cannot be compiled for the selected MCU variant"
   #endif
 
+  #ifndef MODEM
+    #if BOARD_MODEL == BOARD_RAK4631
+      #define MODEM SX1262
+    #elif BOARD_MODEL == BOARD_GENERIC_NRF52
+      #define MODEM SX1262
+    #else
+      #define MODEM SX1276
+    #endif
+  #endif
+
+  #define LORA_PA_UNKNOWN  0x00
+  #define LORA_PA_GC1109   0x01
+  #define LORA_PA_KCT8103L 0x02
+
   #define HAS_DISPLAY false
   #define HAS_BLUETOOTH false
   #define HAS_BLE false
@@ -264,7 +278,7 @@
       };
 
       #elif BOARD_VARIANT == MODEL_E3 || BOARD_VARIANT == MODEL_E8
-      #define OCP_TUNED 0x18
+      #define OCP_TUNED 0x28
       const uint8_t interfaces[INTERFACE_COUNT] = {SX1262};
       const bool interface_cfg[INTERFACE_COUNT][3] = {
                     // SX1262
@@ -545,7 +559,7 @@
       #define PIN_WAKEUP GPIO_NUM_0
       #define WAKEUP_LEVEL 0
       #define INTERFACE_COUNT 1
-      #define OCP_TUNED 0x18
+      #define OCP_TUNED 0x28
 
       const int pin_btn_usr1 = 0;
 
@@ -658,8 +672,9 @@
       #define HAS_LORA_LNA true
       #define PIN_WAKEUP GPIO_NUM_0
       #define WAKEUP_LEVEL 0
-      #define OCP_TUNED 0x18
+      #define OCP_TUNED 0x28
       #define Vext GPIO_NUM_36
+      #define LORA_PA_MODEL LORA_PA_UNKNOWN;
 
       const int pin_btn_usr1 = 0;
 
@@ -681,14 +696,17 @@
 
       #define LORA_LNA_GAIN  17
       #define LORA_LNA_GVT   14
-      #define LORA_PA_GC1109 true
       #define LORA_PA_PWR_EN  7
-      #define LORA_PA_CSD     2
-      #define LORA_PA_CPS    46
+      #define LORA_PA_CSD     2 // Same pin on GC1109
+      #define LORA_PA_CPS    46 // Same pin on GC1109
+      #define LORA_PA_CTX     5 // Only used on KCT8103
 
       #define PA_MAX_OUTPUT  28
       #define PA_GAIN_POINTS 22
-      #define PA_GAIN_VALUES 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 10, 10, 9, 9, 8, 7
+      
+      #define LORA_LNA_KCT8103L_GAIN 21
+      const int PA_GC1109_VALUES[PA_GAIN_POINTS] =   {11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 10, 10,  9, 9, 8, 7};
+      const int PA_KCT8103L_VALUES[PA_GAIN_POINTS] = {13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 12, 12, 11, 11, 10, 9, 8, 7};
 
       const int pin_cs = 8;
       const int pin_busy = 13;
@@ -986,7 +1004,7 @@
 
     #elif BOARD_MODEL == BOARD_TBEAM_S_V1
       #define IS_ESP32S3 true
-      #define OCP_TUNED 0x18
+      #define OCP_TUNED 0x28
 
       #define HAS_DISPLAY true
       #define DISPLAY MONO_OLED
@@ -1475,7 +1493,7 @@
   // Default OCP value if not specified
   // in board configuration
   #ifndef OCP_TUNED
-    #define OCP_TUNED 0x18
+    #define OCP_TUNED 0x28
   #endif
 
   #ifndef NP_M

--- a/Boards.h
+++ b/Boards.h
@@ -678,7 +678,7 @@
       #define DIO2_AS_RF_SWITCH true
 
       #define LORA_LNA_GAIN  17
-      #define LORA_LNA_GVT   12
+      #define LORA_LNA_GVT   14
       #define LORA_PA_GC1109 true
       #define LORA_PA_PWR_EN  7
       #define LORA_PA_CSD     2

--- a/Boards.h
+++ b/Boards.h
@@ -112,6 +112,10 @@
   #define BOARD_E22_ESP32     0x45 // Custom Ebyte E22 board design for meshtastic, source:
                                    // https://github.com/NanoVHF/Meshtastic-DIY/blob/main/Schematics/E-Byte_E22/Mesh_Ebyte_E22-XXXM30S.pdf
 
+  #define PRODUCT_H32_V4      0xC3
+  #define BOARD_HELTEC32_V4   0x3B
+  #define MODEL_C8            0xC8 // Heltec Lora32 v4, 850-950 MHz, 28dBm
+
   #define PRODUCT_HELTEC_T114 0xC2 // Heltec Mesh Node T114
   #define BOARD_HELTEC_T114   0x3C
   #define MODEL_C6            0xC6 // Heltec Mesh Node T114, 470-510 MHz
@@ -637,6 +641,44 @@
       const int pin_disp_reset = 6;
       const int pin_disp_busy = 7;
       const int pin_disp_en = 45;
+
+    #elif BOARD_MODEL == BOARD_HELTEC32_V4
+      #define IS_ESP32S3 true
+      #define HAS_DISPLAY true
+      #define HAS_BLUETOOTH false
+      #define HAS_BLE true
+      #define HAS_PMU true
+      #define HAS_CONSOLE true
+      #define HAS_EEPROM true
+      #define HAS_INPUT true
+      #define HAS_SLEEP true
+      #define PIN_WAKEUP GPIO_NUM_0
+      #define WAKEUP_LEVEL 0
+      #define OCP_TUNED 0x18
+
+      const int pin_btn_usr1 = 0;
+
+      #if defined(EXTERNAL_LEDS)
+        const int pin_led_rx = 13;
+        const int pin_led_tx = 14;
+      #else
+        const int pin_led_rx = 35;
+        const int pin_led_tx = 35;
+      #endif
+
+      #define MODEM SX1262
+      #define HAS_TCXO true
+      const int pin_tcxo_enable = -1;
+      #define HAS_BUSY true
+      #define DIO2_AS_RF_SWITCH true
+
+      const int pin_cs = 8;
+      const int pin_busy = 13;
+      const int pin_dio = 14;
+      const int pin_reset = 12;
+      const int pin_mosi = 10;
+      const int pin_miso = 11;
+      const int pin_sclk = 9;
 
     #elif BOARD_MODEL == BOARD_RNODE_NG_20
       #define HAS_DISPLAY true

--- a/Boards.h
+++ b/Boards.h
@@ -114,7 +114,8 @@
 
   #define PRODUCT_H32_V4      0xC3
   #define BOARD_HELTEC32_V4   0x43
-  #define MODEL_C8            0xC8 // Heltec Lora32 v4, 850-950 MHz, 28dBm
+  #define MODEL_C8            0xC8 // Heltec Lora32 v4 (R2, 2MB PSRAM), 850-950 MHz, 28dBm
+  #define MODEL_CC            0xCC // Heltec Lora32 v4 (R8, 8MB PSRAM), 850-950 MHz, 28dBm
 
   #define PRODUCT_HELTEC_T114 0xC2 // Heltec Mesh Node T114
   #define BOARD_HELTEC_T114   0x3C
@@ -670,10 +671,15 @@
       #define HAS_SLEEP true
       #define HAS_LORA_PA true
       #define HAS_LORA_LNA true
+      #define INTERFACE_COUNT 1
       #define PIN_WAKEUP GPIO_NUM_0
       #define WAKEUP_LEVEL 0
       #define OCP_TUNED 0x28
-      #define Vext GPIO_NUM_36
+      #if BOARD_VARIANT == MODEL_CC
+        #define Vext GPIO_NUM_40 // R8 variant (ESP32-S3R8, 8MB Octal PSRAM)
+      #else
+        #define Vext GPIO_NUM_36 // R2 variant (ESP32-S3R2, 2MB Quad PSRAM)
+      #endif
       #define LORA_PA_MODEL LORA_PA_UNKNOWN;
 
       const int pin_btn_usr1 = 0;
@@ -681,6 +687,9 @@
       #if defined(EXTERNAL_LEDS)
         const int pin_led_rx = 13;
         const int pin_led_tx = 14;
+      #elif BOARD_VARIANT == MODEL_CC
+        const int pin_led_rx = 46;
+        const int pin_led_tx = 46;
       #else
         const int pin_led_rx = 35;
         const int pin_led_tx = 35;
@@ -715,6 +724,31 @@
       const int pin_mosi = 10;
       const int pin_miso = 11;
       const int pin_sclk = 9;
+
+      const uint8_t interfaces[INTERFACE_COUNT] = {SX1262};
+      const bool interface_cfg[INTERFACE_COUNT][3] = {
+                    // SX1262
+          {
+              true, // DEFAULT_SPI
+              true, // HAS_TCXO
+              true  // DIO2_AS_RF_SWITCH
+          },
+      };
+      const int8_t interface_pins[INTERFACE_COUNT][10] = {
+                  // SX1262
+          {
+              8,  // pin_ss
+              9,  // pin_sclk
+              10, // pin_mosi
+              11, // pin_miso
+              13, // pin_busy
+              14, // pin_dio
+              12, // pin_reset
+              -1, // pin_txen
+              -1, // pin_rxen
+              -1  // pin_tcxo_enable
+          }
+      };
 
     #elif BOARD_MODEL == BOARD_RNODE_NG_20
       #define HAS_DISPLAY true

--- a/Boards.h
+++ b/Boards.h
@@ -113,7 +113,7 @@
                                    // https://github.com/NanoVHF/Meshtastic-DIY/blob/main/Schematics/E-Byte_E22/Mesh_Ebyte_E22-XXXM30S.pdf
 
   #define PRODUCT_H32_V4      0xC3
-  #define BOARD_HELTEC32_V4   0x3B
+  #define BOARD_HELTEC32_V4   0x43
   #define MODEL_C8            0xC8 // Heltec Lora32 v4, 850-950 MHz, 28dBm
 
   #define PRODUCT_HELTEC_T114 0xC2 // Heltec Mesh Node T114
@@ -162,6 +162,8 @@
   #define HAS_EEPROM false
   #define HAS_INPUT false
   #define HAS_SLEEP false
+  #define HAS_LORA_PA false
+  #define HAS_LORA_LNA false
   #define PIN_DISP_SLEEP -1
   #define VALIDATE_FIRMWARE true
 
@@ -652,9 +654,12 @@
       #define HAS_EEPROM true
       #define HAS_INPUT true
       #define HAS_SLEEP true
+      #define HAS_LORA_PA true
+      #define HAS_LORA_LNA true
       #define PIN_WAKEUP GPIO_NUM_0
       #define WAKEUP_LEVEL 0
       #define OCP_TUNED 0x18
+      #define Vext GPIO_NUM_36
 
       const int pin_btn_usr1 = 0;
 
@@ -671,6 +676,16 @@
       const int pin_tcxo_enable = -1;
       #define HAS_BUSY true
       #define DIO2_AS_RF_SWITCH true
+
+      #define LORA_LNA_GAIN  17
+      #define LORA_PA_GC1109 true
+      #define LORA_PA_PWR_EN  7
+      #define LORA_PA_CSD     2
+      #define LORA_PA_CPS    46
+
+      #define PA_MAX_OUTPUT  28
+      #define PA_GAIN_POINTS 22
+      #define PA_GAIN_VALUES 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 10, 10, 9, 9, 8, 7
 
       const int pin_cs = 8;
       const int pin_busy = 13;

--- a/Boards.h
+++ b/Boards.h
@@ -676,6 +676,8 @@
       const int pin_tcxo_enable = -1;
       #define HAS_BUSY true
       #define DIO2_AS_RF_SWITCH true
+      #define LNA_GD_THRSHLD (-109)
+      #define LNA_GD_LIMIT   (-89)
 
       #define LORA_LNA_GAIN  17
       #define LORA_LNA_GVT   14

--- a/Display.h
+++ b/Display.h
@@ -497,7 +497,7 @@ bool display_init() {
             disp_mode = DISP_MODE_PORTRAIT;
             #endif
           #elif BOARD_MODEL == BOARD_TECHO
-            disp_mode = DISP_MODE_PORTRAIT;
+            disp_mode = DISP_MODE_LANDSCAPE;
             display.setRotation(3);
           #elif BOARD_MODEL == BOARD_HELTEC32_V3
             disp_mode = DISP_MODE_PORTRAIT;

--- a/Display.h
+++ b/Display.h
@@ -491,11 +491,6 @@ bool display_init() {
         #elif BOARD_MODEL == BOARD_HELTEC32_V2
           disp_mode = DISP_MODE_PORTRAIT;
           display.setRotation(1);
-        #elif BOARD_MODEL == BOARD_RAK4631 || BOARD_MODEL == BOARD_OPENCOM_XL
-          #if DISPLAY == OLED
-          #elif DISPLAY == EINK_BW || DISPLAY == EINK_3C
-          disp_mode = DISP_MODE_PORTRAIT;
-          #endif
         #elif BOARD_MODEL == BOARD_HELTEC32_V3
           disp_mode = DISP_MODE_PORTRAIT;
           display.setRotation(1);
@@ -506,8 +501,10 @@ bool display_init() {
           disp_mode = DISP_MODE_PORTRAIT;
           display.setRotation(1);
         #elif BOARD_MODEL == BOARD_RAK4631 || BOARD_MODEL == BOARD_OPENCOM_XL
-          disp_mode = DISP_MODE_LANDSCAPE;
-          display.setRotation(0);
+          #if DISPLAY == OLED
+          #elif DISPLAY == EINK_BW || DISPLAY == EINK_3C
+          disp_mode = DISP_MODE_PORTRAIT;
+          #endif
         #elif BOARD_MODEL == BOARD_TDECK
           disp_mode = DISP_MODE_PORTRAIT;
           display.setRotation(3);

--- a/Display.h
+++ b/Display.h
@@ -692,20 +692,20 @@ void draw_battery_bars(int px, int py) {
           stat_area.drawBitmap(px-2, py-2, bm_plug, 17, 7, DISPLAY_WHITE, DISPLAY_BLACK);
         } else {
           if (battery_state == BATTERY_STATE_CHARGED) {
-              stat_area.fillRect(px-2, py-2, 18, 7, DISPLAY_BLACK);
-              stat_area.drawBitmap(px-2, py-2, bm_plug, 17, 7, DISPLAY_WHITE, DISPLAY_BLACK);
+            stat_area.fillRect(px-2, py-2, 18, 7, DISPLAY_BLACK);
+            stat_area.drawBitmap(px-2, py-2, bm_plug, 17, 7, DISPLAY_WHITE, DISPLAY_BLACK);
           } else {
-                stat_area.fillRect(px, py, 14, 3, DISPLAY_BLACK);
-                stat_area.fillRect(px-2, py-2, 18, 7, DISPLAY_BLACK);
-                stat_area.drawRect(px-2, py-2, 17, 7, DISPLAY_WHITE);
-                stat_area.drawLine(px+15, py, px+15, py+3, DISPLAY_WHITE);
-                if (battery_value > 7) stat_area.drawLine(px, py, px, py+2, DISPLAY_WHITE);
-                if (battery_value > 20) stat_area.drawLine(px+1*2, py, px+1*2, py+2, DISPLAY_WHITE);
-                if (battery_value > 33) stat_area.drawLine(px+2*2, py, px+2*2, py+2, DISPLAY_WHITE);
-                if (battery_value > 46) stat_area.drawLine(px+3*2, py, px+3*2, py+2, DISPLAY_WHITE);
-                if (battery_value > 59) stat_area.drawLine(px+4*2, py, px+4*2, py+2, DISPLAY_WHITE);
-                if (battery_value > 72) stat_area.drawLine(px+5*2, py, px+5*2, py+2, DISPLAY_WHITE);
-                if (battery_value > 85) stat_area.drawLine(px+6*2, py, px+6*2, py+2, DISPLAY_WHITE);
+            stat_area.fillRect(px, py, 14, 3, DISPLAY_BLACK);
+            stat_area.fillRect(px-2, py-2, 18, 7, DISPLAY_BLACK);
+            stat_area.drawRect(px-2, py-2, 17, 7, DISPLAY_WHITE);
+            stat_area.drawLine(px+15, py, px+15, py+3, DISPLAY_WHITE);
+            if (battery_value > 7) stat_area.drawLine(px, py, px, py+2, DISPLAY_WHITE);
+            if (battery_value > 20) stat_area.drawLine(px+1*2, py, px+1*2, py+2, DISPLAY_WHITE);
+            if (battery_value > 33) stat_area.drawLine(px+2*2, py, px+2*2, py+2, DISPLAY_WHITE);
+            if (battery_value > 46) stat_area.drawLine(px+3*2, py, px+3*2, py+2, DISPLAY_WHITE);
+            if (battery_value > 59) stat_area.drawLine(px+4*2, py, px+4*2, py+2, DISPLAY_WHITE);
+            if (battery_value > 72) stat_area.drawLine(px+5*2, py, px+5*2, py+2, DISPLAY_WHITE);
+            if (battery_value > 85) stat_area.drawLine(px+6*2, py, px+6*2, py+2, DISPLAY_WHITE);
           }
         }
       } else {

--- a/Display.h
+++ b/Display.h
@@ -225,6 +225,7 @@ uint8_t online_interfaces = 0;
 #define WATERFALL_SIZE 46
 
 int waterfall[INTERFACE_COUNT][WATERFALL_SIZE] = {0};
+int waterfall_meta[INTERFACE_COUNT][WATERFALL_SIZE] = {0};
 int waterfall_head[INTERFACE_COUNT] = {0};
 
 int p_ad_x = 0;
@@ -784,18 +785,24 @@ void draw_signal_bars(int px, int py) {
 #define WF_RSSI_MIN -135
 #define WF_RSSI_SPAN (WF_RSSI_MAX - WF_RSSI_MIN)
 #define WF_PIXEL_WIDTH 10
+#define WF_M_RX   0x00
+#define WF_M_TX   0x01
+#define WF_M_NTFR 0x02
 void draw_waterfall(int px, int py) {
   int rssi_val = interface_obj[interface_page]->currentRssi();
   if (rssi_val < WF_RSSI_MIN) rssi_val = WF_RSSI_MIN;
   if (rssi_val > WF_RSSI_MAX) rssi_val = WF_RSSI_MAX;
   int rssi_normalised = ((rssi_val - WF_RSSI_MIN)*(1.0/WF_RSSI_SPAN))*WF_PIXEL_WIDTH;
   if (display_tx[interface_page]) {
-    for (uint8_t i; i < WF_TX_SIZE; i++) {
+    for (uint8_t i = 0; i < WF_TX_SIZE; i++) {
+      waterfall_meta[interface_page][waterfall_head[interface_page]] = WF_M_TX;
       waterfall[interface_page][waterfall_head[interface_page]++] = -1;
       if (waterfall_head[interface_page] >= WATERFALL_SIZE) waterfall_head[interface_page] = 0;
     }
     display_tx[interface_page] = false;
   } else {
+    if (interface_obj[interface_page]->getInterference()) { waterfall_meta[interface_page][waterfall_head[interface_page]] = WF_M_NTFR; }
+    else                                                   { waterfall_meta[interface_page][waterfall_head[interface_page]] = WF_M_RX; }
     waterfall[interface_page][waterfall_head[interface_page]++] = rssi_normalised;
     if (waterfall_head[interface_page] >= WATERFALL_SIZE) waterfall_head[interface_page] = 0;
   }
@@ -804,8 +811,13 @@ void draw_waterfall(int px, int py) {
   for (int i = 0; i < WATERFALL_SIZE; i++){
     int wi = (waterfall_head[interface_page]+i)%WATERFALL_SIZE;
     int ws = waterfall[interface_page][wi];
+    int wm = waterfall_meta[interface_page][wi];
     if (ws > 0) {
-      stat_area.drawLine(px, py+i, px+ws-1, py+i, DISPLAY_WHITE);
+      if      (wm == WF_M_RX)   { stat_area.drawLine(px, py+i, px+ws-1, py+i, DISPLAY_WHITE); }
+      else if (wm == WF_M_NTFR) {
+        uint8_t o = 0;
+        for (uint8_t ti = 0; ti < WF_PIXEL_WIDTH/2; ti++) { stat_area.drawPixel(px+ti*2+o, py+i, DISPLAY_WHITE); }
+      }
     } else if (ws == -1) {
       uint8_t o = i%2;
       for (uint8_t ti = 0; ti < WF_PIXEL_WIDTH/2; ti++) {

--- a/Display.h
+++ b/Display.h
@@ -491,6 +491,11 @@ bool display_init() {
         #elif BOARD_MODEL == BOARD_HELTEC32_V2
           disp_mode = DISP_MODE_PORTRAIT;
           display.setRotation(1);
+        #elif BOARD_MODEL == BOARD_RAK4631 || BOARD_MODEL == BOARD_OPENCOM_XL
+          #if DISPLAY == OLED
+          #elif DISPLAY == EINK_BW || DISPLAY == EINK_3C
+          disp_mode = DISP_MODE_PORTRAIT;
+          #endif
         #elif BOARD_MODEL == BOARD_HELTEC32_V3
           disp_mode = DISP_MODE_PORTRAIT;
           display.setRotation(1);

--- a/Display.h
+++ b/Display.h
@@ -85,6 +85,11 @@ void busyCallback(const void* p) { display_callback(); }
   #define DISP_ADDR 0x3C
   #define SCL_OLED 18
   #define SDA_OLED 17
+#elif BOARD_MODEL == BOARD_HELTEC32_V4
+  #define DISP_RST 21
+  #define DISP_ADDR 0x3C
+  #define SCL_OLED 18
+  #define SDA_OLED 17
 #elif BOARD_MODEL == BOARD_RNODE_NG_21
   #if DISPLAY == OLED
   #define DISP_RST -1
@@ -341,6 +346,18 @@ bool display_init() {
       digitalWrite(pin_display_en, HIGH);
       delay(50);
       Wire.begin(SDA_OLED, SCL_OLED);
+    #elif BOARD_MODEL == BOARD_HELTEC32_V4
+      // enable vext / pin 36
+      pinMode(Vext, OUTPUT);
+      digitalWrite(Vext, LOW);
+      delay(50);
+      int pin_display_en = 21;
+      pinMode(pin_display_en, OUTPUT);
+      digitalWrite(pin_display_en, LOW);
+      delay(50);
+      digitalWrite(pin_display_en, HIGH);
+      delay(50);
+      Wire.begin(SDA_OLED, SCL_OLED);
     #elif BOARD_MODEL == BOARD_LORA32_V1_0
       int pin_display_en = 16;
       digitalWrite(pin_display_en, LOW);
@@ -449,51 +466,49 @@ bool display_init() {
         }
         display.setRotation(display_rotation);
       } else {
-          #if BOARD_MODEL == BOARD_RNODE_NG_20
-            disp_mode = DISP_MODE_PORTRAIT;
-            display.setRotation(3);
-          #elif BOARD_MODEL == BOARD_RNODE_NG_21
-            disp_mode = DISP_MODE_PORTRAIT;
-            display.setRotation(3);
-          #elif BOARD_MODEL == BOARD_LORA32_V1_0
-            disp_mode = DISP_MODE_PORTRAIT;
-            display.setRotation(3);
-          #elif BOARD_MODEL == BOARD_LORA32_V2_0
-            disp_mode = DISP_MODE_PORTRAIT;
-            display.setRotation(3);
-          #elif BOARD_MODEL == BOARD_LORA32_V2_1
-            disp_mode = DISP_MODE_LANDSCAPE;
-            display.setRotation(0);
-          #elif BOARD_MODEL == BOARD_TBEAM
-            disp_mode = DISP_MODE_LANDSCAPE;
-            display.setRotation(0);
-          #elif BOARD_MODEL == BOARD_TBEAM_S_V1
-            disp_mode = DISP_MODE_PORTRAIT;
-            display.setRotation(1);
-          #elif BOARD_MODEL == BOARD_HELTEC32_V2
-            disp_mode = DISP_MODE_PORTRAIT;
-            display.setRotation(1);
-          #elif BOARD_MODEL == BOARD_RAK4631 || BOARD_MODEL == BOARD_OPENCOM_XL
-            #if DISPLAY == OLED
-            #elif DISPLAY == EINK_BW || DISPLAY == EINK_3C
-            disp_mode = DISP_MODE_PORTRAIT;
-            #endif
-          #elif BOARD_MODEL == BOARD_TECHO
-            disp_mode = DISP_MODE_LANDSCAPE;
-            display.setRotation(3);
-          #elif BOARD_MODEL == BOARD_HELTEC32_V3
-            disp_mode = DISP_MODE_PORTRAIT;
-            display.setRotation(1);
-          #elif BOARD_MODEL == BOARD_RAK4631 || BOARD_MODEL == BOARD_OPENCOM_XL
-            disp_mode = DISP_MODE_LANDSCAPE;
-            display.setRotation(0);
-          #elif BOARD_MODEL == BOARD_TDECK
-            disp_mode = DISP_MODE_PORTRAIT;
-            display.setRotation(3);
-          #else
-            disp_mode = DISP_MODE_PORTRAIT;
-            display.setRotation(3);
-          #endif
+        #if BOARD_MODEL == BOARD_RNODE_NG_20
+          disp_mode = DISP_MODE_PORTRAIT;
+          display.setRotation(3);
+        #elif BOARD_MODEL == BOARD_RNODE_NG_21
+          disp_mode = DISP_MODE_PORTRAIT;
+          display.setRotation(3);
+        #elif BOARD_MODEL == BOARD_LORA32_V1_0
+          disp_mode = DISP_MODE_PORTRAIT;
+          display.setRotation(3);
+        #elif BOARD_MODEL == BOARD_LORA32_V2_0
+          disp_mode = DISP_MODE_PORTRAIT;
+          display.setRotation(3);
+        #elif BOARD_MODEL == BOARD_LORA32_V2_1
+          disp_mode = DISP_MODE_LANDSCAPE;
+          display.setRotation(0);
+        #elif BOARD_MODEL == BOARD_TBEAM
+          disp_mode = DISP_MODE_LANDSCAPE;
+          display.setRotation(0);
+        #elif BOARD_MODEL == BOARD_TBEAM_S_V1
+          disp_mode = DISP_MODE_PORTRAIT;
+          display.setRotation(1);
+        #elif BOARD_MODEL == BOARD_HELTEC32_V2
+          disp_mode = DISP_MODE_PORTRAIT;
+          display.setRotation(1);
+        #elif BOARD_MODEL == BOARD_HELTEC32_V3
+          disp_mode = DISP_MODE_PORTRAIT;
+          display.setRotation(1);
+        #elif BOARD_MODEL == BOARD_HELTEC_T114
+          disp_mode = DISP_MODE_PORTRAIT;
+          display.setRotation(1);
+        #elif BOARD_MODEL == BOARD_RAK4631
+          disp_mode = DISP_MODE_LANDSCAPE;
+          display.setRotation(0);
+        #elif BOARD_MODEL == BOARD_TDECK
+          disp_mode = DISP_MODE_PORTRAIT;
+          display.setRotation(3);
+        #elif BOARD_MODEL == BOARD_TECHO
+          disp_mode = DISP_MODE_PORTRAIT;
+          display.setRotation(3);
+        #else
+          disp_mode = DISP_MODE_PORTRAIT;
+          display.setRotation(3);
+        #endif
       }
 
       update_area_positions();

--- a/Display.h
+++ b/Display.h
@@ -494,10 +494,13 @@ bool display_init() {
         #elif BOARD_MODEL == BOARD_HELTEC32_V3
           disp_mode = DISP_MODE_PORTRAIT;
           display.setRotation(1);
+        #elif BOARD_MODEL == BOARD_HELTEC32_V4
+          disp_mode = DISP_MODE_PORTRAIT;
+          display.setRotation(1);
         #elif BOARD_MODEL == BOARD_HELTEC_T114
           disp_mode = DISP_MODE_PORTRAIT;
           display.setRotation(1);
-        #elif BOARD_MODEL == BOARD_RAK4631
+        #elif BOARD_MODEL == BOARD_RAK4631 || BOARD_MODEL == BOARD_OPENCOM_XL
           disp_mode = DISP_MODE_LANDSCAPE;
           display.setRotation(0);
         #elif BOARD_MODEL == BOARD_TDECK

--- a/Display.h
+++ b/Display.h
@@ -467,54 +467,54 @@ bool display_init() {
         }
         display.setRotation(display_rotation);
       } else {
-        #if BOARD_MODEL == BOARD_RNODE_NG_20
-          disp_mode = DISP_MODE_PORTRAIT;
-          display.setRotation(3);
-        #elif BOARD_MODEL == BOARD_RNODE_NG_21
-          disp_mode = DISP_MODE_PORTRAIT;
-          display.setRotation(3);
-        #elif BOARD_MODEL == BOARD_LORA32_V1_0
-          disp_mode = DISP_MODE_PORTRAIT;
-          display.setRotation(3);
-        #elif BOARD_MODEL == BOARD_LORA32_V2_0
-          disp_mode = DISP_MODE_PORTRAIT;
-          display.setRotation(3);
-        #elif BOARD_MODEL == BOARD_LORA32_V2_1
-          disp_mode = DISP_MODE_LANDSCAPE;
-          display.setRotation(0);
-        #elif BOARD_MODEL == BOARD_TBEAM
-          disp_mode = DISP_MODE_LANDSCAPE;
-          display.setRotation(0);
-        #elif BOARD_MODEL == BOARD_TBEAM_S_V1
-          disp_mode = DISP_MODE_PORTRAIT;
-          display.setRotation(1);
-        #elif BOARD_MODEL == BOARD_HELTEC32_V2
-          disp_mode = DISP_MODE_PORTRAIT;
-          display.setRotation(1);
-        #elif BOARD_MODEL == BOARD_HELTEC32_V3
-          disp_mode = DISP_MODE_PORTRAIT;
-          display.setRotation(1);
-        #elif BOARD_MODEL == BOARD_HELTEC32_V4
-          disp_mode = DISP_MODE_PORTRAIT;
-          display.setRotation(1);
-        #elif BOARD_MODEL == BOARD_HELTEC_T114
-          disp_mode = DISP_MODE_PORTRAIT;
-          display.setRotation(1);
-        #elif BOARD_MODEL == BOARD_RAK4631 || BOARD_MODEL == BOARD_OPENCOM_XL
-          #if DISPLAY == OLED
-          #elif DISPLAY == EINK_BW || DISPLAY == EINK_3C
-          disp_mode = DISP_MODE_PORTRAIT;
+          #if BOARD_MODEL == BOARD_RNODE_NG_20
+            disp_mode = DISP_MODE_PORTRAIT;
+            display.setRotation(3);
+          #elif BOARD_MODEL == BOARD_RNODE_NG_21
+            disp_mode = DISP_MODE_PORTRAIT;
+            display.setRotation(3);
+          #elif BOARD_MODEL == BOARD_LORA32_V1_0
+            disp_mode = DISP_MODE_PORTRAIT;
+            display.setRotation(3);
+          #elif BOARD_MODEL == BOARD_LORA32_V2_0
+            disp_mode = DISP_MODE_PORTRAIT;
+            display.setRotation(3);
+          #elif BOARD_MODEL == BOARD_LORA32_V2_1
+            disp_mode = DISP_MODE_LANDSCAPE;
+            display.setRotation(0);
+          #elif BOARD_MODEL == BOARD_TBEAM
+            disp_mode = DISP_MODE_LANDSCAPE;
+            display.setRotation(0);
+          #elif BOARD_MODEL == BOARD_TBEAM_S_V1
+            disp_mode = DISP_MODE_PORTRAIT;
+            display.setRotation(1);
+          #elif BOARD_MODEL == BOARD_HELTEC32_V2
+            disp_mode = DISP_MODE_PORTRAIT;
+            display.setRotation(1);
+          #elif BOARD_MODEL == BOARD_RAK4631 || BOARD_MODEL == BOARD_OPENCOM_XL
+            #if DISPLAY == OLED
+            #elif DISPLAY == EINK_BW || DISPLAY == EINK_3C
+            disp_mode = DISP_MODE_PORTRAIT;
+            #endif
+          #elif BOARD_MODEL == BOARD_TECHO
+            disp_mode = DISP_MODE_PORTRAIT;
+            display.setRotation(3);
+          #elif BOARD_MODEL == BOARD_HELTEC32_V3
+            disp_mode = DISP_MODE_PORTRAIT;
+            display.setRotation(1);
+          #elif BOARD_MODEL == BOARD_HELTEC32_V4
+            disp_mode = DISP_MODE_PORTRAIT;
+            display.setRotation(1);
+          #elif BOARD_MODEL == BOARD_HELTEC_T114
+            disp_mode = DISP_MODE_PORTRAIT;
+            display.setRotation(1);
+          #elif BOARD_MODEL == BOARD_TDECK
+            disp_mode = DISP_MODE_PORTRAIT;
+            display.setRotation(3);
+          #else
+            disp_mode = DISP_MODE_PORTRAIT;
+            display.setRotation(3);
           #endif
-        #elif BOARD_MODEL == BOARD_TDECK
-          disp_mode = DISP_MODE_PORTRAIT;
-          display.setRotation(3);
-        #elif BOARD_MODEL == BOARD_TECHO
-          disp_mode = DISP_MODE_PORTRAIT;
-          display.setRotation(3);
-        #else
-          disp_mode = DISP_MODE_PORTRAIT;
-          display.setRotation(3);
-        #endif
       }
 
       update_area_positions();
@@ -697,20 +697,20 @@ void draw_battery_bars(int px, int py) {
           stat_area.drawBitmap(px-2, py-2, bm_plug, 17, 7, DISPLAY_WHITE, DISPLAY_BLACK);
         } else {
           if (battery_state == BATTERY_STATE_CHARGED) {
-            stat_area.fillRect(px-2, py-2, 18, 7, DISPLAY_BLACK);
-            stat_area.drawBitmap(px-2, py-2, bm_plug, 17, 7, DISPLAY_WHITE, DISPLAY_BLACK);
+              stat_area.fillRect(px-2, py-2, 18, 7, DISPLAY_BLACK);
+              stat_area.drawBitmap(px-2, py-2, bm_plug, 17, 7, DISPLAY_WHITE, DISPLAY_BLACK);
           } else {
-            stat_area.fillRect(px, py, 14, 3, DISPLAY_BLACK);
-            stat_area.fillRect(px-2, py-2, 18, 7, DISPLAY_BLACK);
-            stat_area.drawRect(px-2, py-2, 17, 7, DISPLAY_WHITE);
-            stat_area.drawLine(px+15, py, px+15, py+3, DISPLAY_WHITE);
-            if (battery_value > 7) stat_area.drawLine(px, py, px, py+2, DISPLAY_WHITE);
-            if (battery_value > 20) stat_area.drawLine(px+1*2, py, px+1*2, py+2, DISPLAY_WHITE);
-            if (battery_value > 33) stat_area.drawLine(px+2*2, py, px+2*2, py+2, DISPLAY_WHITE);
-            if (battery_value > 46) stat_area.drawLine(px+3*2, py, px+3*2, py+2, DISPLAY_WHITE);
-            if (battery_value > 59) stat_area.drawLine(px+4*2, py, px+4*2, py+2, DISPLAY_WHITE);
-            if (battery_value > 72) stat_area.drawLine(px+5*2, py, px+5*2, py+2, DISPLAY_WHITE);
-            if (battery_value > 85) stat_area.drawLine(px+6*2, py, px+6*2, py+2, DISPLAY_WHITE);
+                stat_area.fillRect(px, py, 14, 3, DISPLAY_BLACK);
+                stat_area.fillRect(px-2, py-2, 18, 7, DISPLAY_BLACK);
+                stat_area.drawRect(px-2, py-2, 17, 7, DISPLAY_WHITE);
+                stat_area.drawLine(px+15, py, px+15, py+3, DISPLAY_WHITE);
+                if (battery_value > 7) stat_area.drawLine(px, py, px, py+2, DISPLAY_WHITE);
+                if (battery_value > 20) stat_area.drawLine(px+1*2, py, px+1*2, py+2, DISPLAY_WHITE);
+                if (battery_value > 33) stat_area.drawLine(px+2*2, py, px+2*2, py+2, DISPLAY_WHITE);
+                if (battery_value > 46) stat_area.drawLine(px+3*2, py, px+3*2, py+2, DISPLAY_WHITE);
+                if (battery_value > 59) stat_area.drawLine(px+4*2, py, px+4*2, py+2, DISPLAY_WHITE);
+                if (battery_value > 72) stat_area.drawLine(px+5*2, py, px+5*2, py+2, DISPLAY_WHITE);
+                if (battery_value > 85) stat_area.drawLine(px+6*2, py, px+6*2, py+2, DISPLAY_WHITE);
           }
         }
       } else {

--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,9 @@ VFLAG =-v
 endif
 
 COMMON_BUILD_FLAGS =  $(VFLAG) -e --build-property "build.partitions=no_ota" --build-property "upload.maximum_size=2097152"
-COMMON_ESP_UPLOAD_FLAGS = $(VFLAG) --chip esp32 --baud 921600 --before default_reset --after hard_reset write_flash -z --flash_mode dio --flash_freq 80m --flash_size 4MB 0x210000
+COMMON_UPLOAD_FLAGS = $(VFLAG) --baud 921600 --before default_reset --after hard_reset write_flash -z --flash_mode dio --flash_freq 80m
+4MB_ESP32 = $(VFLAG) --chip esp32 --flash_size 4MB 0x210000
+4MB_ESP32-S3 = $(VFLAG) --chip esp32-s3 --flash_size 4MB 0x210000
 
 all: release
 
@@ -125,17 +127,23 @@ firmware-heltec32_v2_extled: check_bt_buffers
 firmware-heltec32_v3:
 	arduino-cli compile --fqbn esp32:esp32:heltec_wifi_lora_32_V3 $(COMMON_BUILD_FLAGS) --build-property "compiler.cpp.extra_flags=\"-DBOARD_MODEL=0x3A\""
 
+firmware-heltec32_v4:
+	arduino-cli compile --fqbn "esp32:esp32:esp32s3:CDCOnBoot=cdc" $(COMMON_BUILD_FLAGS) --build-property "compiler.cpp.extra_flags=\"-DBOARD_MODEL=0x43\""
+
+firmware-heltec32_v4_r8:
+	arduino-cli compile --fqbn "esp32:esp32:esp32s3:CDCOnBoot=cdc" $(COMMON_BUILD_FLAGS) --build-property "compiler.cpp.extra_flags=\"-DBOARD_MODEL=0x43\" \"-DBOARD_VARIANT=0xCC\""
+
 firmware-heltec_w_paper:
 	arduino-cli compile --fqbn esp32:esp32:heltec_wifi_lora_32_V3 $(COMMON_BUILD_FLAGS) --build-property "compiler.cpp.extra_flags=\"-DBOARD_MODEL=0x3E\""
 
+firmware-heltec_t114:
+	arduino-cli compile --fqbn Heltec_nRF52:Heltec_nRF52:HT-n5262 $(COMMON_BUILD_FLAGS) --build-property "compiler.cpp.extra_flags=\"-DBOARD_MODEL=0x3C\""
+
+firmware-heltec_t114_gps:
+	arduino-cli compile --fqbn Heltec_nRF52:Heltec_nRF52:HT-n5262 $(COMMON_BUILD_FLAGS) --build-property "compiler.cpp.extra_flags=\"-DBOARD_MODEL=0x3C\" \"-DBOARD_VARIANT=0xCB\""
+
 firmware-xiao_s3:
 	arduino-cli compile --fqbn esp32:esp32:XIAO_ESP32S3 $(COMMON_BUILD_FLAGS) --build-property "compiler.cpp.extra_flags=\"-DBOARD_MODEL=0x3E\""
-
-firmware-heltec32_v4:
-	arduino-cli compile --log --fqbn "esp32:esp32:esp32s3:CDCOnBoot=cdc" -e --build-property "build.partitions=no_ota" --build-property "upload.maximum_size=2097152" --build-property "compiler.cpp.extra_flags=\"-DBOARD_MODEL=0x43\""
-
-firmware-heltec32_v4_r8:
-	arduino-cli compile --log --fqbn "esp32:esp32:esp32s3:CDCOnBoot=cdc" -e --build-property "build.partitions=no_ota" --build-property "upload.maximum_size=2097152" --build-property "compiler.cpp.extra_flags=\"-DBOARD_MODEL=0x43\" \"-DBOARD_VARIANT=0xCC\""
 
 firmware-rnode_ng_20: check_bt_buffers
 	arduino-cli compile --fqbn esp32:esp32:ttgo-lora32 $(COMMON_BUILD_FLAGS) --build-property "compiler.cpp.extra_flags=\"-DBOARD_MODEL=0x40\""
@@ -158,107 +166,99 @@ firmware-rak4631_sx1280:
 firmware-opencom-xl:
 	arduino-cli compile --fqbn rakwireless:nrf52:WisCoreRAK4631Board $(COMMON_BUILD_FLAGS) --build-property "compiler.cpp.extra_flags=\"-DBOARD_MODEL=0x52\" \"-DBOARD_VARIANT=0x21\""
 
-firmware-heltec_t114:
-	arduino-cli compile --log --fqbn Heltec_nRF52:Heltec_nRF52:HT-n5262 -e --build-property "build.partitions=no_ota" --build-property "upload.maximum_size=2097152" --build-property "compiler.cpp.extra_flags=\"-DBOARD_MODEL=0x3C\""
-
-firmware-heltec_t114_gps:
-	arduino-cli compile --log --fqbn Heltec_nRF52:Heltec_nRF52:HT-n5262 -e --build-property "build.partitions=no_ota" --build-property "upload.maximum_size=2097152" --build-property "compiler.cpp.extra_flags=\"-DBOARD_MODEL=0x3C\" \"-DBOARD_VARIANT=0xCB\""
-
 upload-tbeam:
 	arduino-cli upload -p $(or $(port), /dev/ttyACM0) --fqbn esp32:esp32:t-beam
 	@sleep 1
 	rnodeconf $(or $(port), /dev/ttyACM0) --firmware-hash $$(./partition_hashes ./build/esp32.esp32.t-beam/RNode_Firmware_CE.ino.bin)
 	@sleep 3
-	python3 ./Release/esptool/esptool.py --port $(or $(port), /dev/ttyACM0) $(COMMON_ESP_UPLOAD_FLAGS) ./Release/console_image.bin
+	python3 ./Release/esptool/esptool.py --port $(or $(port), /dev/ttyACM0) $(4MB_ESP32) $(COMMON_UPLOAD_FLAGS) ./Release/console_image.bin
 
 upload-tbeam_sx1262:
 	arduino-cli upload -p /dev/ttyACM0 --fqbn esp32:esp32:t-beam
 	@sleep 1
 	rnodeconf /dev/ttyACM0 --firmware-hash $$(./partition_hashes ./build/esp32.esp32.t-beam/RNode_Firmware_CE.ino.bin)
 	#@sleep 3
-	#python ./Release/esptool/esptool.py --chip esp32 --port /dev/ttyACM0 --baud 921600 --before default_reset --after hard_reset write_flash -z --flash_mode dio --flash_freq 80m --flash_size 4MB 0x210000 ./Release/console_image.bin
+	#python ./Release/esptool/esptool.py --port /dev/ttyACM0 $(4MB_ESP32) $(COMMON_UPLOAD_FLAGS) ./Release/console_image.bin
 
 upload-lora32_v10:
 	arduino-cli upload -p $(or $(port), /dev/ttyUSB0) --fqbn esp32:esp32:ttgo-lora32
 	@sleep 1
 	rnodeconf $(or $(port), /dev/ttyUSB0) --firmware-hash $$(./partition_hashes ./build/esp32.esp32.ttgo-lora32/RNode_Firmware_CE.ino.bin)
 	@sleep 3
-	python3 ./Release/esptool/esptool.py --port $(or $(port), /dev/ttyUSB0) $(COMMON_ESP_UPLOAD_FLAGS) ./Release/console_image.bin
+	python3 ./Release/esptool/esptool.py --port $(or $(port), /dev/ttyUSB0) $(4MB_ESP32) $(COMMON_UPLOAD_FLAGS) ./Release/console_image.bin
 
 upload-lora32_v20:
 	arduino-cli upload -p $(or $(port), /dev/ttyUSB0) --fqbn esp32:esp32:ttgo-lora32
 	@sleep 1
 	rnodeconf $(or $(port), /dev/ttyUSB0) --firmware-hash $$(./partition_hashes ./build/esp32.esp32.ttgo-lora32/RNode_Firmware_CE.ino.bin)
 	@sleep 3
-	python3 ./Release/esptool/esptool.py --port $(or $(port), /dev/ttyUSB0) $(COMMON_ESP_UPLOAD_FLAGS) ./Release/console_image.bin
+	python3 ./Release/esptool/esptool.py --port $(or $(port), /dev/ttyUSB0) $(4MB_ESP32) $(COMMON_UPLOAD_FLAGS) ./Release/console_image.bin
 
 upload-lora32_v21:
 	arduino-cli upload -p $(or $(port), /dev/ttyACM0) --fqbn esp32:esp32:ttgo-lora32
 	@sleep 1
 	rnodeconf $(or $(port), /dev/ttyACM0) --firmware-hash $$(./partition_hashes ./build/esp32.esp32.ttgo-lora32/RNode_Firmware_CE.ino.bin)
 	@sleep 3
-	python3 ./Release/esptool/esptool.py --port $(or $(port), /dev/ttyACM0) $(COMMON_ESP_UPLOAD_FLAGS) ./Release/console_image.bin
+	python3 ./Release/esptool/esptool.py --port $(or $(port), /dev/ttyACM0) $(4MB_ESP32) $(COMMON_UPLOAD_FLAGS) ./Release/console_image.bin
 
 upload-heltec32_v2:
 	arduino-cli upload -p $(or $(port), /dev/ttyUSB0) --fqbn esp32:esp32:heltec_wifi_lora_32_V2
 	@sleep 1
 	rnodeconf $(or $(port), /dev/ttyUSB0) --firmware-hash $$(./partition_hashes ./build/esp32.esp32.heltec_wifi_lora_32_V2/RNode_Firmware_CE.ino.bin)
 	@sleep 3
-	python3 ./Release/esptool/esptool.py --port $(or $(port), /dev/ttyUSB0) $(COMMON_ESP_UPLOAD_FLAGS) ./Release/console_image.bin
+	python3 ./Release/esptool/esptool.py --port $(or $(port), /dev/ttyUSB0) $(4MB_ESP32) $(COMMON_UPLOAD_FLAGS) ./Release/console_image.bin
 
 upload-heltec_w_paper upload-heltec32_v3:
 	arduino-cli upload -p $(or $(port), /dev/ttyUSB0) --fqbn esp32:esp32:heltec_wifi_lora_32_V3
 	@sleep 1
 	rnodeconf $(or $(port), /dev/ttyUSB0) --firmware-hash $$(./partition_hashes ./build/esp32.esp32.heltec_wifi_lora_32_V3/RNode_Firmware_CE.ino.bin)
 	@sleep 3
-	python3 ./Release/esptool/esptool.py --port $(or $(port), /dev/ttyUSB0) --chip esp32-s3 --baud 921600 --before default_reset --after hard_reset write_flash -z --flash_mode dio --flash_freq 80m --flash_size 4MB 0x210000 ./Release/console_image.bin
-
-upload-xiao_s3:
-	arduino-cli upload -p $(or $(port), /dev/ttyACM0) --fqbn esp32:esp32:XIAO_ESP32S3
-	@sleep 1
-	rnodeconf $(or $(port), /dev/ttyACM0) --firmware-hash $$(./partition_hashes ./build/esp32.esp32.XIAO_ESP32S3/RNode_Firmware_CE.ino.bin)
-	@sleep 3
-	python ./Release/esptool/esptool.py --port $(or $(port), /dev/ttyACM0) --chip esp32-s3 --baud 921600 --before default_reset --after hard_reset write_flash -z --flash_mode dio --flash_freq 80m --flash_size 8MB 0x210000 ./Release/console_image.bin
+	python3 ./Release/esptool/esptool.py --port $(or $(port), /dev/ttyUSB0) $(4MB_ESP32-S3) $(COMMON_UPLOAD_FLAGS) ./Release/console_image.bin
 
 upload-heltec32_v4:
 	arduino-cli upload -p $(or $(port), /dev/ttyACM0) --fqbn esp32:esp32:esp32s3
 	@sleep 1
 	rnodeconf $(or $(port), /dev/ttyACM0) --firmware-hash $$(./partition_hashes ./build/esp32.esp32.esp32s3/RNode_Firmware_CE.ino.bin)
 	@sleep 3
-	python ./Release/esptool/esptool.py --chip esp32-s3 --port $(or $(port), /dev/ttyACM0) --baud 921600 --before default_reset --after hard_reset write_flash -z --flash_mode dio --flash_freq 80m --flash_size 16MB 0x210000 ./Release/console_image.bin
+	python ./Release/esptool/esptool.py --port $(or $(port), /dev/ttyACM0) --chip esp32-s3 --flash_size 16MB 0x210000 $(COMMON_UPLOAD_FLAGS) ./Release/console_image.bin
+
+upload-heltec_t114:
+	arduino-cli upload -p /dev/ttyACM0 --fqbn Heltec_nRF52:Heltec_nRF52:HT-n5262
+	@sleep 1
+	rnodeconf /dev/ttyACM0 --firmware-hash $$(./partition_hashes from_device /dev/ttyACM0)
 
 upload-tdeck:
 	arduino-cli upload -p $(or $(port), /dev/ttyACM0) --fqbn esp32:esp32:esp32s3
 	@sleep 1
 	rnodeconf $(or $(port), /dev/ttyACM0) --firmware-hash $$(./partition_hashes ./build/esp32.esp32.esp32s3/RNode_Firmware_CE.ino.bin)
 	@sleep 3
-	python ./Release/esptool/esptool.py --port $(or $(port), /dev/ttyACM0) --chip esp32-s3 --baud 921600 --before default_reset --after hard_reset write_flash -z --flash_mode dio --flash_freq 80m --flash_size 4MB 0x210000 ./Release/console_image.bin
+	python ./Release/esptool/esptool.py --port $(or $(port), /dev/ttyACM0) $(4MB_ESP32-S3) $(COMMON_UPLOAD_FLAGS) ./Release/console_image.bin
 
 upload-tbeam_supreme:
 	arduino-cli upload -p $(or $(port), /dev/ttyACM0) --fqbn esp32:esp32:esp32s3
 	@sleep 1
 	rnodeconf $(or $(port), /dev/ttyACM0) --firmware-hash $$(./partition_hashes ./build/esp32.esp32.esp32s3/RNode_Firmware_CE.ino.bin)
 	@sleep 3
-	python ./Release/esptool/esptool.py --port $(or $(port), /dev/ttyACM0) --chip esp32-s3 --baud 921600 --before default_reset --after hard_reset write_flash -z --flash_mode dio --flash_freq 80m --flash_size 4MB 0x210000 ./Release/console_image.bin
+	python ./Release/esptool/esptool.py --port $(or $(port), /dev/ttyACM0) $(4MB_ESP32-S3) $(COMMON_UPLOAD_FLAGS) ./Release/console_image.bin
 
 upload-rnode_ng_20:
 	arduino-cli upload -p $(or $(port), /dev/ttyUSB0) --fqbn esp32:esp32:ttgo-lora32
 	@sleep 1
 	rnodeconf $(or $(port), /dev/ttyUSB0) --firmware-hash $$(./partition_hashes ./build/esp32.esp32.ttgo-lora32/RNode_Firmware_CE.ino.bin)
 	@sleep 3
-	python3 ./Release/esptool/esptool.py --port $(or $(port), /dev/ttyUSB0) $(COMMON_ESP_UPLOAD_FLAGS) ./Release/console_image.bin
+	python3 ./Release/esptool/esptool.py --port $(or $(port), /dev/ttyUSB0) $(4MB_ESP32) $(COMMON_UPLOAD_FLAGS) ./Release/console_image.bin
 
 upload-rnode_ng_21:
 	arduino-cli upload -p $(or $(port), /dev/ttyACM0) --fqbn esp32:esp32:ttgo-lora32
 	@sleep 1
 	rnodeconf $(or $(port), /dev/ttyACM0) --firmware-hash $$(./partition_hashes ./build/esp32.esp32.ttgo-lora32/RNode_Firmware_CE.ino.bin)
 	@sleep 3
-	python3 ./Release/esptool/esptool.py --port $(or $(port), /dev/ttyACM0) $(COMMON_ESP_UPLOAD_FLAGS) ./Release/console_image.bin
+	python3 ./Release/esptool/esptool.py --port $(or $(port), /dev/ttyACM0) $(4MB_ESP32) $(COMMON_UPLOAD_FLAGS) ./Release/console_image.bin
 
 upload-t3s3:
 	arduino-cli upload -p $(or $(port), /dev/ttyACM0) --fqbn esp32:esp32:esp32s3
 	@sleep 1
-	python ./Release/esptool/esptool.py --port $(or $(port), /dev/ttyACM0) --chip esp32-s3 --baud 921600 --before default_reset --after hard_reset write_flash -z --flash_mode dio --flash_freq 80m --flash_size 4MB 0x210000 ./Release/console_image.bin
+	python ./Release/esptool/esptool.py --port $(or $(port), /dev/ttyACM0) $(4MB_ESP32-S3) $(COMMON_UPLOAD_FLAGS) ./Release/console_image.bin
 	@sleep 3
 	rnodeconf $(or $(port), /dev/ttyACM0) --firmware-hash $$(./partition_hashes ./build/esp32.esp32.esp32s3/RNode_Firmware_CE.ino.bin)
 
@@ -279,12 +279,7 @@ upload-e22_esp32:
 	@sleep 1
 	rnodeconf $(or $(port), /dev/ttyUSB0) --firmware-hash $$(./partition_hashes ./build/esp32.esp32.esp32/RNode_Firmware_CE.ino.bin)
 	@sleep 3
-	python3 ./Release/esptool/esptool.py --port $(or $(port), /dev/ttyUSB0) $(COMMON_ESP_UPLOAD_FLAGS)  ./Release/console_image.bin
-
-upload-heltec_t114:
-	arduino-cli upload -p /dev/ttyACM0 --fqbn Heltec_nRF52:Heltec_nRF52:HT-n5262
-	@sleep 1
-	rnodeconf /dev/ttyACM0 --firmware-hash $$(./partition_hashes from_device /dev/ttyACM0)
+	python3 ./Release/esptool/esptool.py --port $(or $(port), /dev/ttyUSB0) $(4MB_ESP32) $(COMMON_UPLOAD_FLAGS)  ./Release/console_image.bin
 
 upload-techo:
 	arduino-cli upload -p /dev/ttyACM0 --fqbn adafruit:nrf52:pca10056
@@ -292,11 +287,11 @@ upload-techo:
 	rnodeconf /dev/ttyACM0 --firmware-hash $$(./partition_hashes from_device /dev/ttyACM0)
 
 upload-xiao_s3:
-	arduino-cli upload -p /dev/ttyACM0 --fqbn esp32:esp32:XIAO_ESP32S3
+	arduino-cli upload -p $(or $(port), /dev/ttyACM0) --fqbn esp32:esp32:XIAO_ESP32S3
 	@sleep 1
-	rnodeconf /dev/ttyACM0 --firmware-hash $$(./partition_hashes ./build/esp32.esp32.XIAO_ESP32S3/RNode_Firmware_CE.ino.bin)
+	rnodeconf $(or $(port), /dev/ttyACM0) --firmware-hash $$(./partition_hashes ./build/esp32.esp32.XIAO_ESP32S3/RNode_Firmware_CE.ino.bin)
 	@sleep 3
-	python ./Release/esptool/esptool.py --chip esp32s3 --port /dev/ttyACM0 --baud 921600 --before default_reset --after hard_reset write_flash -z --flash_mode dio --flash_freq 80m --flash_size 4MB 0x210000 ./Release/console_image.bin
+	python ./Release/esptool/esptool.py --port /dev/ttyACM0 $(4MB_ESP32-S3) $(COMMON_UPLOAD_FLAGS) ./Release/console_image.bin
 
 release:  console-site spiffs-image $(shell grep ^release- Makefile | cut -d: -f1)
 
@@ -400,6 +395,24 @@ release-heltec32_v3:
 	zip --junk-paths ./Release/rnode_firmware_heltec32v3.zip ./Release/esptool/esptool.py ./Release/console_image.bin build/rnode_firmware_heltec32v3.boot_app0 build/rnode_firmware_heltec32v3.bin build/rnode_firmware_heltec32v3.bootloader build/rnode_firmware_heltec32v3.partitions
 	rm -r build
 
+release-heltec32_v4: check_bt_buffers
+	arduino-cli compile --fqbn esp32:esp32:esp32s3 $(COMMON_BUILD_FLAGS) --build-property "compiler.cpp.extra_flags=\"-DBOARD_MODEL=0x43\""
+	cp ~/.arduino15/packages/esp32/hardware/esp32/$(ARDUINO_ESP_CORE_VER)/tools/partitions/boot_app0.bin build/rnode_firmware_heltec32v4pa.boot_app0
+	cp build/esp32.esp32.esp32s3/RNode_Firmware_CE.ino.bin build/rnode_firmware_heltec32v4pa.bin
+	cp build/esp32.esp32.esp32s3/RNode_Firmware_CE.ino.bootloader.bin build/rnode_firmware_heltec32v4pa.bootloader
+	cp build/esp32.esp32.esp32s3/RNode_Firmware_CE.ino.partitions.bin build/rnode_firmware_heltec32v4pa.partitions
+	zip --junk-paths ./Release/rnode_firmware_heltec32v4pa.zip ./Release/esptool/esptool.py ./Release/console_image.bin build/rnode_firmware_heltec32v4pa.boot_app0 build/rnode_firmware_heltec32v4pa.bin build/rnode_firmware_heltec32v4pa.bootloader build/rnode_firmware_heltec32v4pa.partitions
+	rm -r build
+
+release-heltec32_v4_r8: check_bt_buffers
+	arduino-cli compile --fqbn esp32:esp32:esp32s3 $(COMMON_BUILD_FLAGS) --build-property "compiler.cpp.extra_flags=\"-DBOARD_MODEL=0x43\" \"-DBOARD_VARIANT=0xCC\""
+	cp ~/.arduino15/packages/esp32/hardware/esp32/$(ARDUINO_ESP_CORE_VER)/tools/partitions/boot_app0.bin build/rnode_firmware_heltec32v4r8pa.boot_app0
+	cp build/esp32.esp32.esp32s3/RNode_Firmware_CE.ino.bin build/rnode_firmware_heltec32v4r8pa.bin
+	cp build/esp32.esp32.esp32s3/RNode_Firmware_CE.ino.bootloader.bin build/rnode_firmware_heltec32v4r8pa.bootloader
+	cp build/esp32.esp32.esp32s3/RNode_Firmware_CE.ino.partitions.bin build/rnode_firmware_heltec32v4r8pa.partitions
+	zip --junk-paths ./Release/rnode_firmware_heltec32v4r8pa.zip ./Release/esptool/esptool.py ./Release/console_image.bin build/rnode_firmware_heltec32v4r8pa.boot_app0 build/rnode_firmware_heltec32v4r8pa.bin build/rnode_firmware_heltec32v4r8pa.bootloader build/rnode_firmware_heltec32v4r8pa.partitions
+	rm -r build
+
 release-heltec_w_paper:
 	arduino-cli compile --fqbn esp32:esp32:heltec_wifi_lora_32_V3 $(COMMON_BUILD_FLAGS) --build-property "compiler.cpp.extra_flags=\"-DBOARD_MODEL=0x3E\""
 	cp ~/.arduino15/packages/esp32/hardware/esp32/$(ARDUINO_ESP_CORE_VER)/tools/partitions/boot_app0.bin build/rnode_firmware_heltecwpaper.boot_app0
@@ -416,24 +429,6 @@ release-xiao_s3:
 	cp build/esp32.esp32.XIAO_ESP32S3/RNode_Firmware_CE.ino.bootloader.bin build/rnode_firmware_xiao_esp32s3.bootloader
 	cp build/esp32.esp32.XIAO_ESP32S3/RNode_Firmware_CE.ino.partitions.bin build/rnode_firmware_xiao_esp32s3.partitions
 	zip --junk-paths ./Release/rnode_firmware_xiao_esp32s3.zip ./Release/esptool/esptool.py ./Release/console_image.bin build/rnode_firmware_xiao_esp32s3.boot_app0 build/rnode_firmware_xiao_esp32s3.bin build/rnode_firmware_xiao_esp32s3.bootloader build/rnode_firmware_xiao_esp32s3.partitions
-
-release-heltec32_v4: check_bt_buffers
-	arduino-cli compile --fqbn esp32:esp32:heltec_wifi_lora_32_V3 -e --build-property "build.partitions=no_ota" --build-property "upload.maximum_size=2097152" --build-property "compiler.cpp.extra_flags=\"-DBOARD_MODEL=0x43\""
-	cp ~/.arduino15/packages/esp32/hardware/esp32/$(ARDUINO_ESP_CORE_VER)/tools/partitions/boot_app0.bin build/rnode_firmware_heltec32v4pa.boot_app0
-	cp build/esp32.esp32.heltec_wifi_lora_32_V3/RNode_Firmware_CE.ino.bin build/rnode_firmware_heltec32v4pa.bin
-	cp build/esp32.esp32.heltec_wifi_lora_32_V3/RNode_Firmware_CE.ino.bootloader.bin build/rnode_firmware_heltec32v4pa.bootloader
-	cp build/esp32.esp32.heltec_wifi_lora_32_V3/RNode_Firmware_CE.ino.partitions.bin build/rnode_firmware_heltec32v4pa.partitions
-	zip --junk-paths ./Release/rnode_firmware_heltec32v4pa.zip ./Release/esptool/esptool.py ./Release/console_image.bin build/rnode_firmware_heltec32v4pa.boot_app0 build/rnode_firmware_heltec32v4pa.bin build/rnode_firmware_heltec32v4pa.bootloader build/rnode_firmware_heltec32v4pa.partitions
-	rm -r build
-
-release-heltec32_v4_r8: check_bt_buffers
-	arduino-cli compile --fqbn esp32:esp32:heltec_wifi_lora_32_V3 -e --build-property "build.partitions=no_ota" --build-property "upload.maximum_size=2097152" --build-property "compiler.cpp.extra_flags=\"-DBOARD_MODEL=0x43\" \"-DBOARD_VARIANT=0xCC\""
-	cp ~/.arduino15/packages/esp32/hardware/esp32/$(ARDUINO_ESP_CORE_VER)/tools/partitions/boot_app0.bin build/rnode_firmware_heltec32v4r8pa.boot_app0
-	cp build/esp32.esp32.heltec_wifi_lora_32_V3/RNode_Firmware_CE.ino.bin build/rnode_firmware_heltec32v4r8pa.bin
-	cp build/esp32.esp32.heltec_wifi_lora_32_V3/RNode_Firmware_CE.ino.bootloader.bin build/rnode_firmware_heltec32v4r8pa.bootloader
-	cp build/esp32.esp32.heltec_wifi_lora_32_V3/RNode_Firmware_CE.ino.partitions.bin build/rnode_firmware_heltec32v4r8pa.partitions
-	zip --junk-paths ./Release/rnode_firmware_heltec32v4r8pa.zip ./Release/esptool/esptool.py ./Release/console_image.bin build/rnode_firmware_heltec32v4r8pa.boot_app0 build/rnode_firmware_heltec32v4r8pa.bin build/rnode_firmware_heltec32v4r8pa.bootloader build/rnode_firmware_heltec32v4r8pa.partitions
-	rm -r build
 
 release-heltec32_v2_extled: check_bt_buffers
 	arduino-cli compile --fqbn esp32:esp32:heltec_wifi_lora_32_V2 $(COMMON_BUILD_FLAGS) --build-property "compiler.cpp.extra_flags=\"-DBOARD_MODEL=0x38\" \"-DEXTERNAL_LEDS=true\""
@@ -478,7 +473,7 @@ release-t3s3:
 	rm -r build
 
 release-t3s3_sx127x:
-	arduino-cli compile --fqbn "esp32:esp32:esp32s3:CDCOnBoot=cdc" -e --build-property "build.partitions=no_ota" --build-property "upload.maximum_size=2097152" --build-property "compiler.cpp.extra_flags=\"-DBOARD_MODEL=0x42\" \"-DBOARD_VARIANT=0xA5\""
+	arduino-cli compile --fqbn "esp32:esp32:esp32s3:CDCOnBoot=cdc" $(COMMON_BUILD_FLAGS) --build-property "compiler.cpp.extra_flags=\"-DBOARD_MODEL=0x42\" \"-DBOARD_VARIANT=0xA5\""
 	cp ~/.arduino15/packages/esp32/hardware/esp32/$(ARDUINO_ESP_CORE_VER)/tools/partitions/boot_app0.bin build/rnode_firmware_t3s3_sx127x.boot_app0
 	cp build/esp32.esp32.esp32s3/RNode_Firmware_CE.ino.bin build/rnode_firmware_t3s3_sx127x.bin
 	cp build/esp32.esp32.esp32s3/RNode_Firmware_CE.ino.bootloader.bin build/rnode_firmware_t3s3_sx127x.bootloader
@@ -487,7 +482,7 @@ release-t3s3_sx127x:
 	rm -r build
 
 release-t3s3_sx1280_pa:
-	arduino-cli compile --fqbn "esp32:esp32:esp32s3:CDCOnBoot=cdc" -e --build-property "build.partitions=no_ota" --build-property "upload.maximum_size=2097152" --build-property "compiler.cpp.extra_flags=\"-DBOARD_MODEL=0x42\" \"-DBOARD_VARIANT=0xAC\""
+	arduino-cli compile --fqbn "esp32:esp32:esp32s3:CDCOnBoot=cdc" $(COMMON_BUILD_FLAGS) --build-property "compiler.cpp.extra_flags=\"-DBOARD_MODEL=0x42\" \"-DBOARD_VARIANT=0xAC\""
 	cp ~/.arduino15/packages/esp32/hardware/esp32/$(ARDUINO_ESP_CORE_VER)/tools/partitions/boot_app0.bin build/rnode_firmware_t3s3_sx1280_pa.boot_app0
 	cp build/esp32.esp32.esp32s3/RNode_Firmware_CE.ino.bin build/rnode_firmware_t3s3_sx1280_pa.bin
 	cp build/esp32.esp32.esp32s3/RNode_Firmware_CE.ino.bootloader.bin build/rnode_firmware_t3s3_sx1280_pa.bootloader
@@ -513,7 +508,6 @@ release-tdeck:
 	zip --junk-paths ./Release/rnode_firmware_tdeck.zip ./Release/esptool/esptool.py ./Release/console_image.bin build/rnode_firmware_tdeck.boot_app0 build/rnode_firmware_tdeck.bin build/rnode_firmware_tdeck.bootloader build/rnode_firmware_tdeck.partitions
 	rm -r build
 
-
 release-tbeam_supreme:
 	arduino-cli compile --fqbn "esp32:esp32:esp32s3:CDCOnBoot=cdc" $(COMMON_BUILD_FLAGS) --build-property "compiler.cpp.extra_flags=\"-DBOARD_MODEL=0x3D\""
 	cp ~/.arduino15/packages/esp32/hardware/esp32/$(ARDUINO_ESP_CORE_VER)/tools/partitions/boot_app0.bin build/rnode_firmware_tbeam_supreme.boot_app0
@@ -522,7 +516,6 @@ release-tbeam_supreme:
 	cp build/esp32.esp32.esp32s3/RNode_Firmware_CE.ino.partitions.bin build/rnode_firmware_tbeam_supreme.partitions
 	zip --junk-paths ./Release/rnode_firmware_tbeam_supreme.zip ./Release/esptool/esptool.py ./Release/console_image.bin build/rnode_firmware_tbeam_supreme.boot_app0 build/rnode_firmware_tbeam_supreme.bin build/rnode_firmware_tbeam_supreme.bootloader build/rnode_firmware_tbeam_supreme.partitions
 	rm -r build
-
 
 release-featheresp32: check_bt_buffers
 	arduino-cli compile --fqbn esp32:esp32:featheresp32 $(COMMON_BUILD_FLAGS) --build-property "compiler.cpp.extra_flags=\"-DBOARD_MODEL=0x34\""

--- a/Makefile
+++ b/Makefile
@@ -132,7 +132,10 @@ firmware-xiao_s3:
 	arduino-cli compile --fqbn esp32:esp32:XIAO_ESP32S3 $(COMMON_BUILD_FLAGS) --build-property "compiler.cpp.extra_flags=\"-DBOARD_MODEL=0x3E\""
 
 firmware-heltec32_v4:
-	arduino-cli compile --log --fqbn "esp32:esp32:esp32s3:CDCOnBoot=cdc" -e --build-property "build.partitions=no_ota" --build-property "upload.maximum_size=2097152" --build-property "compiler.cpp.extra_flags=\"-DBOARD_MODEL=0x3F\""
+	arduino-cli compile --log --fqbn "esp32:esp32:esp32s3:CDCOnBoot=cdc" -e --build-property "build.partitions=no_ota" --build-property "upload.maximum_size=2097152" --build-property "compiler.cpp.extra_flags=\"-DBOARD_MODEL=0x43\""
+
+firmware-heltec32_v4_r8:
+	arduino-cli compile --log --fqbn "esp32:esp32:esp32s3:CDCOnBoot=cdc" -e --build-property "build.partitions=no_ota" --build-property "upload.maximum_size=2097152" --build-property "compiler.cpp.extra_flags=\"-DBOARD_MODEL=0x43\" \"-DBOARD_VARIANT=0xCC\""
 
 firmware-rnode_ng_20: check_bt_buffers
 	arduino-cli compile --fqbn esp32:esp32:ttgo-lora32 $(COMMON_BUILD_FLAGS) --build-property "compiler.cpp.extra_flags=\"-DBOARD_MODEL=0x40\""
@@ -421,6 +424,15 @@ release-heltec32_v4: check_bt_buffers
 	cp build/esp32.esp32.heltec_wifi_lora_32_V3/RNode_Firmware_CE.ino.bootloader.bin build/rnode_firmware_heltec32v4pa.bootloader
 	cp build/esp32.esp32.heltec_wifi_lora_32_V3/RNode_Firmware_CE.ino.partitions.bin build/rnode_firmware_heltec32v4pa.partitions
 	zip --junk-paths ./Release/rnode_firmware_heltec32v4pa.zip ./Release/esptool/esptool.py ./Release/console_image.bin build/rnode_firmware_heltec32v4pa.boot_app0 build/rnode_firmware_heltec32v4pa.bin build/rnode_firmware_heltec32v4pa.bootloader build/rnode_firmware_heltec32v4pa.partitions
+	rm -r build
+
+release-heltec32_v4_r8: check_bt_buffers
+	arduino-cli compile --fqbn esp32:esp32:heltec_wifi_lora_32_V3 -e --build-property "build.partitions=no_ota" --build-property "upload.maximum_size=2097152" --build-property "compiler.cpp.extra_flags=\"-DBOARD_MODEL=0x43\" \"-DBOARD_VARIANT=0xCC\""
+	cp ~/.arduino15/packages/esp32/hardware/esp32/$(ARDUINO_ESP_CORE_VER)/tools/partitions/boot_app0.bin build/rnode_firmware_heltec32v4r8pa.boot_app0
+	cp build/esp32.esp32.heltec_wifi_lora_32_V3/RNode_Firmware_CE.ino.bin build/rnode_firmware_heltec32v4r8pa.bin
+	cp build/esp32.esp32.heltec_wifi_lora_32_V3/RNode_Firmware_CE.ino.bootloader.bin build/rnode_firmware_heltec32v4r8pa.bootloader
+	cp build/esp32.esp32.heltec_wifi_lora_32_V3/RNode_Firmware_CE.ino.partitions.bin build/rnode_firmware_heltec32v4r8pa.partitions
+	zip --junk-paths ./Release/rnode_firmware_heltec32v4r8pa.zip ./Release/esptool/esptool.py ./Release/console_image.bin build/rnode_firmware_heltec32v4r8pa.boot_app0 build/rnode_firmware_heltec32v4r8pa.bin build/rnode_firmware_heltec32v4r8pa.bootloader build/rnode_firmware_heltec32v4r8pa.partitions
 	rm -r build
 
 release-heltec32_v2_extled: check_bt_buffers

--- a/Makefile
+++ b/Makefile
@@ -23,9 +23,7 @@ VFLAG =-v
 endif
 
 COMMON_BUILD_FLAGS =  $(VFLAG) -e --build-property "build.partitions=no_ota" --build-property "upload.maximum_size=2097152"
-COMMON_UPLOAD_FLAGS = $(VFLAG) --baud 921600 --before default_reset --after hard_reset write_flash -z --flash_mode dio --flash_freq 80m
-4MB_ESP32 = $(VFLAG) --chip esp32 --flash_size 4MB 0x210000
-4MB_ESP32-S3 = $(VFLAG) --chip esp32-s3 --flash_size 4MB 0x210000
+COMMON_ESP_UPLOAD_FLAGS = $(VFLAG) --chip esp32 --baud 921600 --before default_reset --after hard_reset write_flash -z --flash_mode dio --flash_freq 80m --flash_size 4MB 0x210000
 
 all: release
 
@@ -136,12 +134,6 @@ firmware-heltec32_v4_r8:
 firmware-heltec_w_paper:
 	arduino-cli compile --fqbn esp32:esp32:heltec_wifi_lora_32_V3 $(COMMON_BUILD_FLAGS) --build-property "compiler.cpp.extra_flags=\"-DBOARD_MODEL=0x3E\""
 
-firmware-heltec_t114:
-	arduino-cli compile --fqbn Heltec_nRF52:Heltec_nRF52:HT-n5262 $(COMMON_BUILD_FLAGS) --build-property "compiler.cpp.extra_flags=\"-DBOARD_MODEL=0x3C\""
-
-firmware-heltec_t114_gps:
-	arduino-cli compile --fqbn Heltec_nRF52:Heltec_nRF52:HT-n5262 $(COMMON_BUILD_FLAGS) --build-property "compiler.cpp.extra_flags=\"-DBOARD_MODEL=0x3C\" \"-DBOARD_VARIANT=0xCB\""
-
 firmware-xiao_s3:
 	arduino-cli compile --fqbn esp32:esp32:XIAO_ESP32S3 $(COMMON_BUILD_FLAGS) --build-property "compiler.cpp.extra_flags=\"-DBOARD_MODEL=0x3E\""
 
@@ -166,54 +158,60 @@ firmware-rak4631_sx1280:
 firmware-opencom-xl:
 	arduino-cli compile --fqbn rakwireless:nrf52:WisCoreRAK4631Board $(COMMON_BUILD_FLAGS) --build-property "compiler.cpp.extra_flags=\"-DBOARD_MODEL=0x52\" \"-DBOARD_VARIANT=0x21\""
 
+firmware-heltec_t114:
+	arduino-cli compile --fqbn Heltec_nRF52:Heltec_nRF52:HT-n5262 $(COMMON_BUILD_FLAGS) --build-property "compiler.cpp.extra_flags=\"-DBOARD_MODEL=0x3C\""
+
+firmware-heltec_t114_gps:
+	arduino-cli compile --fqbn Heltec_nRF52:Heltec_nRF52:HT-n5262 $(COMMON_BUILD_FLAGS) --build-property "compiler.cpp.extra_flags=\"-DBOARD_MODEL=0x3C\" \"-DBOARD_VARIANT=0xCB\""
+
 upload-tbeam:
 	arduino-cli upload -p $(or $(port), /dev/ttyACM0) --fqbn esp32:esp32:t-beam
 	@sleep 1
 	rnodeconf $(or $(port), /dev/ttyACM0) --firmware-hash $$(./partition_hashes ./build/esp32.esp32.t-beam/RNode_Firmware_CE.ino.bin)
 	@sleep 3
-	python3 ./Release/esptool/esptool.py --port $(or $(port), /dev/ttyACM0) $(4MB_ESP32) $(COMMON_UPLOAD_FLAGS) ./Release/console_image.bin
+	python3 ./Release/esptool/esptool.py --port $(or $(port), /dev/ttyACM0) $(COMMON_ESP_UPLOAD_FLAGS) ./Release/console_image.bin
 
 upload-tbeam_sx1262:
 	arduino-cli upload -p /dev/ttyACM0 --fqbn esp32:esp32:t-beam
 	@sleep 1
 	rnodeconf /dev/ttyACM0 --firmware-hash $$(./partition_hashes ./build/esp32.esp32.t-beam/RNode_Firmware_CE.ino.bin)
 	#@sleep 3
-	#python ./Release/esptool/esptool.py --port /dev/ttyACM0 $(4MB_ESP32) $(COMMON_UPLOAD_FLAGS) ./Release/console_image.bin
+	#python ./Release/esptool/esptool.py --chip esp32 --port /dev/ttyACM0 --baud 921600 --before default_reset --after hard_reset write_flash -z --flash_mode dio --flash_freq 80m --flash_size 4MB 0x210000 ./Release/console_image.bin
 
 upload-lora32_v10:
 	arduino-cli upload -p $(or $(port), /dev/ttyUSB0) --fqbn esp32:esp32:ttgo-lora32
 	@sleep 1
 	rnodeconf $(or $(port), /dev/ttyUSB0) --firmware-hash $$(./partition_hashes ./build/esp32.esp32.ttgo-lora32/RNode_Firmware_CE.ino.bin)
 	@sleep 3
-	python3 ./Release/esptool/esptool.py --port $(or $(port), /dev/ttyUSB0) $(4MB_ESP32) $(COMMON_UPLOAD_FLAGS) ./Release/console_image.bin
+	python3 ./Release/esptool/esptool.py --port $(or $(port), /dev/ttyUSB0) $(COMMON_ESP_UPLOAD_FLAGS) ./Release/console_image.bin
 
 upload-lora32_v20:
 	arduino-cli upload -p $(or $(port), /dev/ttyUSB0) --fqbn esp32:esp32:ttgo-lora32
 	@sleep 1
 	rnodeconf $(or $(port), /dev/ttyUSB0) --firmware-hash $$(./partition_hashes ./build/esp32.esp32.ttgo-lora32/RNode_Firmware_CE.ino.bin)
 	@sleep 3
-	python3 ./Release/esptool/esptool.py --port $(or $(port), /dev/ttyUSB0) $(4MB_ESP32) $(COMMON_UPLOAD_FLAGS) ./Release/console_image.bin
+	python3 ./Release/esptool/esptool.py --port $(or $(port), /dev/ttyUSB0) $(COMMON_ESP_UPLOAD_FLAGS) ./Release/console_image.bin
 
 upload-lora32_v21:
 	arduino-cli upload -p $(or $(port), /dev/ttyACM0) --fqbn esp32:esp32:ttgo-lora32
 	@sleep 1
 	rnodeconf $(or $(port), /dev/ttyACM0) --firmware-hash $$(./partition_hashes ./build/esp32.esp32.ttgo-lora32/RNode_Firmware_CE.ino.bin)
 	@sleep 3
-	python3 ./Release/esptool/esptool.py --port $(or $(port), /dev/ttyACM0) $(4MB_ESP32) $(COMMON_UPLOAD_FLAGS) ./Release/console_image.bin
+	python3 ./Release/esptool/esptool.py --port $(or $(port), /dev/ttyACM0) $(COMMON_ESP_UPLOAD_FLAGS) ./Release/console_image.bin
 
 upload-heltec32_v2:
 	arduino-cli upload -p $(or $(port), /dev/ttyUSB0) --fqbn esp32:esp32:heltec_wifi_lora_32_V2
 	@sleep 1
 	rnodeconf $(or $(port), /dev/ttyUSB0) --firmware-hash $$(./partition_hashes ./build/esp32.esp32.heltec_wifi_lora_32_V2/RNode_Firmware_CE.ino.bin)
 	@sleep 3
-	python3 ./Release/esptool/esptool.py --port $(or $(port), /dev/ttyUSB0) $(4MB_ESP32) $(COMMON_UPLOAD_FLAGS) ./Release/console_image.bin
+	python3 ./Release/esptool/esptool.py --port $(or $(port), /dev/ttyUSB0) $(COMMON_ESP_UPLOAD_FLAGS) ./Release/console_image.bin
 
 upload-heltec_w_paper upload-heltec32_v3:
 	arduino-cli upload -p $(or $(port), /dev/ttyUSB0) --fqbn esp32:esp32:heltec_wifi_lora_32_V3
 	@sleep 1
 	rnodeconf $(or $(port), /dev/ttyUSB0) --firmware-hash $$(./partition_hashes ./build/esp32.esp32.heltec_wifi_lora_32_V3/RNode_Firmware_CE.ino.bin)
 	@sleep 3
-	python3 ./Release/esptool/esptool.py --port $(or $(port), /dev/ttyUSB0) $(4MB_ESP32-S3) $(COMMON_UPLOAD_FLAGS) ./Release/console_image.bin
+	python3 ./Release/esptool/esptool.py --port $(or $(port), /dev/ttyUSB0) --chip esp32-s3 --baud 921600 --before default_reset --after hard_reset write_flash -z --flash_mode dio --flash_freq 80m --flash_size 4MB 0x210000 ./Release/console_image.bin
 
 upload-heltec32_v4:
 	arduino-cli upload -p $(or $(port), /dev/ttyACM0) --fqbn esp32:esp32:esp32s3
@@ -222,45 +220,47 @@ upload-heltec32_v4:
 	@sleep 3
 	python ./Release/esptool/esptool.py --port $(or $(port), /dev/ttyACM0) --chip esp32-s3 --flash_size 16MB 0x210000 $(COMMON_UPLOAD_FLAGS) ./Release/console_image.bin
 
-upload-heltec_t114:
-	arduino-cli upload -p /dev/ttyACM0 --fqbn Heltec_nRF52:Heltec_nRF52:HT-n5262
+upload-xiao_s3:
+	arduino-cli upload -p $(or $(port), /dev/ttyACM0) --fqbn esp32:esp32:XIAO_ESP32S3
 	@sleep 1
-	rnodeconf /dev/ttyACM0 --firmware-hash $$(./partition_hashes from_device /dev/ttyACM0)
+	rnodeconf $(or $(port), /dev/ttyACM0) --firmware-hash $$(./partition_hashes ./build/esp32.esp32.XIAO_ESP32S3/RNode_Firmware_CE.ino.bin)
+	@sleep 3
+	python ./Release/esptool/esptool.py --port $(or $(port), /dev/ttyACM0) --chip esp32-s3 --baud 921600 --before default_reset --after hard_reset write_flash -z --flash_mode dio --flash_freq 80m --flash_size 8MB 0x210000 ./Release/console_image.bin
 
 upload-tdeck:
 	arduino-cli upload -p $(or $(port), /dev/ttyACM0) --fqbn esp32:esp32:esp32s3
 	@sleep 1
 	rnodeconf $(or $(port), /dev/ttyACM0) --firmware-hash $$(./partition_hashes ./build/esp32.esp32.esp32s3/RNode_Firmware_CE.ino.bin)
 	@sleep 3
-	python ./Release/esptool/esptool.py --port $(or $(port), /dev/ttyACM0) $(4MB_ESP32-S3) $(COMMON_UPLOAD_FLAGS) ./Release/console_image.bin
+	python ./Release/esptool/esptool.py --port $(or $(port), /dev/ttyACM0) --chip esp32-s3 --baud 921600 --before default_reset --after hard_reset write_flash -z --flash_mode dio --flash_freq 80m --flash_size 4MB 0x210000 ./Release/console_image.bin
 
 upload-tbeam_supreme:
 	arduino-cli upload -p $(or $(port), /dev/ttyACM0) --fqbn esp32:esp32:esp32s3
 	@sleep 1
 	rnodeconf $(or $(port), /dev/ttyACM0) --firmware-hash $$(./partition_hashes ./build/esp32.esp32.esp32s3/RNode_Firmware_CE.ino.bin)
 	@sleep 3
-	python ./Release/esptool/esptool.py --port $(or $(port), /dev/ttyACM0) $(4MB_ESP32-S3) $(COMMON_UPLOAD_FLAGS) ./Release/console_image.bin
+	python ./Release/esptool/esptool.py --port $(or $(port), /dev/ttyACM0) --chip esp32-s3 --baud 921600 --before default_reset --after hard_reset write_flash -z --flash_mode dio --flash_freq 80m --flash_size 4MB 0x210000 ./Release/console_image.bin
 
 upload-rnode_ng_20:
 	arduino-cli upload -p $(or $(port), /dev/ttyUSB0) --fqbn esp32:esp32:ttgo-lora32
 	@sleep 1
 	rnodeconf $(or $(port), /dev/ttyUSB0) --firmware-hash $$(./partition_hashes ./build/esp32.esp32.ttgo-lora32/RNode_Firmware_CE.ino.bin)
 	@sleep 3
-	python3 ./Release/esptool/esptool.py --port $(or $(port), /dev/ttyUSB0) $(4MB_ESP32) $(COMMON_UPLOAD_FLAGS) ./Release/console_image.bin
+	python3 ./Release/esptool/esptool.py --port $(or $(port), /dev/ttyUSB0) $(COMMON_ESP_UPLOAD_FLAGS) ./Release/console_image.bin
 
 upload-rnode_ng_21:
 	arduino-cli upload -p $(or $(port), /dev/ttyACM0) --fqbn esp32:esp32:ttgo-lora32
 	@sleep 1
 	rnodeconf $(or $(port), /dev/ttyACM0) --firmware-hash $$(./partition_hashes ./build/esp32.esp32.ttgo-lora32/RNode_Firmware_CE.ino.bin)
 	@sleep 3
-	python3 ./Release/esptool/esptool.py --port $(or $(port), /dev/ttyACM0) $(4MB_ESP32) $(COMMON_UPLOAD_FLAGS) ./Release/console_image.bin
+	python3 ./Release/esptool/esptool.py --port $(or $(port), /dev/ttyACM0) $(COMMON_ESP_UPLOAD_FLAGS) ./Release/console_image.bin
 
 upload-t3s3:
 	arduino-cli upload -p $(or $(port), /dev/ttyACM0) --fqbn esp32:esp32:esp32s3
 	@sleep 1
 	python ./Release/esptool/esptool.py --port $(or $(port), /dev/ttyACM0) $(4MB_ESP32-S3) $(COMMON_UPLOAD_FLAGS) ./Release/console_image.bin
 	@sleep 3
-	rnodeconf $(or $(port), /dev/ttyACM0) --firmware-hash $$(./partition_hashes ./build/esp32.esp32.esp32s3/RNode_Firmware_CE.ino.bin)
+	python ./Release/esptool/esptool.py --port $(or $(port), /dev/ttyACM0) --chip esp32-s3 --baud 921600 --before default_reset --after hard_reset write_flash -z --flash_mode dio --flash_freq 80m --flash_size 4MB 0x210000 ./Release/console_image.bin
 
 upload-featheresp32:
 	arduino-cli upload -p $(or $(port), /dev/ttyUSB0) --fqbn esp32:esp32:featheresp32
@@ -279,7 +279,12 @@ upload-e22_esp32:
 	@sleep 1
 	rnodeconf $(or $(port), /dev/ttyUSB0) --firmware-hash $$(./partition_hashes ./build/esp32.esp32.esp32/RNode_Firmware_CE.ino.bin)
 	@sleep 3
-	python3 ./Release/esptool/esptool.py --port $(or $(port), /dev/ttyUSB0) $(4MB_ESP32) $(COMMON_UPLOAD_FLAGS)  ./Release/console_image.bin
+	python3 ./Release/esptool/esptool.py --port $(or $(port), /dev/ttyUSB0) $(COMMON_ESP_UPLOAD_FLAGS)  ./Release/console_image.bin
+
+upload-heltec_t114:
+	arduino-cli upload -p /dev/ttyACM0 --fqbn Heltec_nRF52:Heltec_nRF52:HT-n5262
+	@sleep 1
+	rnodeconf /dev/ttyACM0 --firmware-hash $$(./partition_hashes from_device /dev/ttyACM0)
 
 upload-techo:
 	arduino-cli upload -p /dev/ttyACM0 --fqbn adafruit:nrf52:pca10056
@@ -385,6 +390,7 @@ release-heltec32_v2: check_bt_buffers
 	cp build/esp32.esp32.heltec_wifi_lora_32_V2/RNode_Firmware_CE.ino.bin build/rnode_firmware_heltec32v2.bin
 	cp build/esp32.esp32.heltec_wifi_lora_32_V2/RNode_Firmware_CE.ino.bootloader.bin build/rnode_firmware_heltec32v2.bootloader
 	cp build/esp32.esp32.heltec_wifi_lora_32_V2/RNode_Firmware_CE.ino.partitions.bin build/rnode_firmware_heltec32v2.partitions
+	rm -r build
 
 release-heltec32_v3:
 	arduino-cli compile --fqbn esp32:esp32:heltec_wifi_lora_32_V3 $(COMMON_BUILD_FLAGS) --build-property "compiler.cpp.extra_flags=\"-DBOARD_MODEL=0x3A\""
@@ -473,7 +479,7 @@ release-t3s3:
 	rm -r build
 
 release-t3s3_sx127x:
-	arduino-cli compile --fqbn "esp32:esp32:esp32s3:CDCOnBoot=cdc" $(COMMON_BUILD_FLAGS) --build-property "compiler.cpp.extra_flags=\"-DBOARD_MODEL=0x42\" \"-DBOARD_VARIANT=0xA5\""
+	arduino-cli compile --fqbn "esp32:esp32:esp32s3:CDCOnBoot=cdc" -e --build-property "build.partitions=no_ota" --build-property "upload.maximum_size=2097152" --build-property "compiler.cpp.extra_flags=\"-DBOARD_MODEL=0x42\" \"-DBOARD_VARIANT=0xA5\""
 	cp ~/.arduino15/packages/esp32/hardware/esp32/$(ARDUINO_ESP_CORE_VER)/tools/partitions/boot_app0.bin build/rnode_firmware_t3s3_sx127x.boot_app0
 	cp build/esp32.esp32.esp32s3/RNode_Firmware_CE.ino.bin build/rnode_firmware_t3s3_sx127x.bin
 	cp build/esp32.esp32.esp32s3/RNode_Firmware_CE.ino.bootloader.bin build/rnode_firmware_t3s3_sx127x.bootloader
@@ -482,7 +488,7 @@ release-t3s3_sx127x:
 	rm -r build
 
 release-t3s3_sx1280_pa:
-	arduino-cli compile --fqbn "esp32:esp32:esp32s3:CDCOnBoot=cdc" $(COMMON_BUILD_FLAGS) --build-property "compiler.cpp.extra_flags=\"-DBOARD_MODEL=0x42\" \"-DBOARD_VARIANT=0xAC\""
+	arduino-cli compile --fqbn "esp32:esp32:esp32s3:CDCOnBoot=cdc" -e --build-property "build.partitions=no_ota" --build-property "upload.maximum_size=2097152" --build-property "compiler.cpp.extra_flags=\"-DBOARD_MODEL=0x42\" \"-DBOARD_VARIANT=0xAC\""
 	cp ~/.arduino15/packages/esp32/hardware/esp32/$(ARDUINO_ESP_CORE_VER)/tools/partitions/boot_app0.bin build/rnode_firmware_t3s3_sx1280_pa.boot_app0
 	cp build/esp32.esp32.esp32s3/RNode_Firmware_CE.ino.bin build/rnode_firmware_t3s3_sx1280_pa.bin
 	cp build/esp32.esp32.esp32s3/RNode_Firmware_CE.ino.bootloader.bin build/rnode_firmware_t3s3_sx1280_pa.bootloader
@@ -508,6 +514,7 @@ release-tdeck:
 	zip --junk-paths ./Release/rnode_firmware_tdeck.zip ./Release/esptool/esptool.py ./Release/console_image.bin build/rnode_firmware_tdeck.boot_app0 build/rnode_firmware_tdeck.bin build/rnode_firmware_tdeck.bootloader build/rnode_firmware_tdeck.partitions
 	rm -r build
 
+
 release-tbeam_supreme:
 	arduino-cli compile --fqbn "esp32:esp32:esp32s3:CDCOnBoot=cdc" $(COMMON_BUILD_FLAGS) --build-property "compiler.cpp.extra_flags=\"-DBOARD_MODEL=0x3D\""
 	cp ~/.arduino15/packages/esp32/hardware/esp32/$(ARDUINO_ESP_CORE_VER)/tools/partitions/boot_app0.bin build/rnode_firmware_tbeam_supreme.boot_app0
@@ -516,6 +523,7 @@ release-tbeam_supreme:
 	cp build/esp32.esp32.esp32s3/RNode_Firmware_CE.ino.partitions.bin build/rnode_firmware_tbeam_supreme.partitions
 	zip --junk-paths ./Release/rnode_firmware_tbeam_supreme.zip ./Release/esptool/esptool.py ./Release/console_image.bin build/rnode_firmware_tbeam_supreme.boot_app0 build/rnode_firmware_tbeam_supreme.bin build/rnode_firmware_tbeam_supreme.bootloader build/rnode_firmware_tbeam_supreme.partitions
 	rm -r build
+
 
 release-featheresp32: check_bt_buffers
 	arduino-cli compile --fqbn esp32:esp32:featheresp32 $(COMMON_BUILD_FLAGS) --build-property "compiler.cpp.extra_flags=\"-DBOARD_MODEL=0x34\""

--- a/Makefile
+++ b/Makefile
@@ -159,10 +159,10 @@ firmware-opencom-xl:
 	arduino-cli compile --fqbn rakwireless:nrf52:WisCoreRAK4631Board $(COMMON_BUILD_FLAGS) --build-property "compiler.cpp.extra_flags=\"-DBOARD_MODEL=0x52\" \"-DBOARD_VARIANT=0x21\""
 
 firmware-heltec_t114:
-	arduino-cli compile --fqbn Heltec_nRF52:Heltec_nRF52:HT-n5262 $(COMMON_BUILD_FLAGS) --build-property "compiler.cpp.extra_flags=\"-DBOARD_MODEL=0x3C\""
+	arduino-cli compile --log --fqbn Heltec_nRF52:Heltec_nRF52:HT-n5262 -e --build-property "build.partitions=no_ota" --build-property "upload.maximum_size=2097152" --build-property "compiler.cpp.extra_flags=\"-DBOARD_MODEL=0x3C\""
 
 firmware-heltec_t114_gps:
-	arduino-cli compile --fqbn Heltec_nRF52:Heltec_nRF52:HT-n5262 $(COMMON_BUILD_FLAGS) --build-property "compiler.cpp.extra_flags=\"-DBOARD_MODEL=0x3C\" \"-DBOARD_VARIANT=0xCB\""
+	arduino-cli compile --log --fqbn Heltec_nRF52:Heltec_nRF52:HT-n5262 -e --build-property "build.partitions=no_ota" --build-property "upload.maximum_size=2097152" --build-property "compiler.cpp.extra_flags=\"-DBOARD_MODEL=0x3C\" \"-DBOARD_VARIANT=0xCB\""
 
 upload-tbeam:
 	arduino-cli upload -p $(or $(port), /dev/ttyACM0) --fqbn esp32:esp32:t-beam
@@ -258,9 +258,9 @@ upload-rnode_ng_21:
 upload-t3s3:
 	arduino-cli upload -p $(or $(port), /dev/ttyACM0) --fqbn esp32:esp32:esp32s3
 	@sleep 1
-	python ./Release/esptool/esptool.py --port $(or $(port), /dev/ttyACM0) $(4MB_ESP32-S3) $(COMMON_UPLOAD_FLAGS) ./Release/console_image.bin
-	@sleep 3
 	python ./Release/esptool/esptool.py --port $(or $(port), /dev/ttyACM0) --chip esp32-s3 --baud 921600 --before default_reset --after hard_reset write_flash -z --flash_mode dio --flash_freq 80m --flash_size 4MB 0x210000 ./Release/console_image.bin
+	@sleep 3
+	rnodeconf $(or $(port), /dev/ttyACM0) --firmware-hash $$(./partition_hashes ./build/esp32.esp32.esp32s3/RNode_Firmware_CE.ino.bin)
 
 upload-featheresp32:
 	arduino-cli upload -p $(or $(port), /dev/ttyUSB0) --fqbn esp32:esp32:featheresp32
@@ -290,13 +290,6 @@ upload-techo:
 	arduino-cli upload -p /dev/ttyACM0 --fqbn adafruit:nrf52:pca10056
 	@sleep 6
 	rnodeconf /dev/ttyACM0 --firmware-hash $$(./partition_hashes from_device /dev/ttyACM0)
-
-upload-xiao_s3:
-	arduino-cli upload -p $(or $(port), /dev/ttyACM0) --fqbn esp32:esp32:XIAO_ESP32S3
-	@sleep 1
-	rnodeconf $(or $(port), /dev/ttyACM0) --firmware-hash $$(./partition_hashes ./build/esp32.esp32.XIAO_ESP32S3/RNode_Firmware_CE.ino.bin)
-	@sleep 3
-	python ./Release/esptool/esptool.py --port /dev/ttyACM0 $(4MB_ESP32-S3) $(COMMON_UPLOAD_FLAGS) ./Release/console_image.bin
 
 release:  console-site spiffs-image $(shell grep ^release- Makefile | cut -d: -f1)
 
@@ -390,7 +383,6 @@ release-heltec32_v2: check_bt_buffers
 	cp build/esp32.esp32.heltec_wifi_lora_32_V2/RNode_Firmware_CE.ino.bin build/rnode_firmware_heltec32v2.bin
 	cp build/esp32.esp32.heltec_wifi_lora_32_V2/RNode_Firmware_CE.ino.bootloader.bin build/rnode_firmware_heltec32v2.bootloader
 	cp build/esp32.esp32.heltec_wifi_lora_32_V2/RNode_Firmware_CE.ino.partitions.bin build/rnode_firmware_heltec32v2.partitions
-	rm -r build
 
 release-heltec32_v3:
 	arduino-cli compile --fqbn esp32:esp32:heltec_wifi_lora_32_V3 $(COMMON_BUILD_FLAGS) --build-property "compiler.cpp.extra_flags=\"-DBOARD_MODEL=0x3A\""
@@ -435,6 +427,7 @@ release-xiao_s3:
 	cp build/esp32.esp32.XIAO_ESP32S3/RNode_Firmware_CE.ino.bootloader.bin build/rnode_firmware_xiao_esp32s3.bootloader
 	cp build/esp32.esp32.XIAO_ESP32S3/RNode_Firmware_CE.ino.partitions.bin build/rnode_firmware_xiao_esp32s3.partitions
 	zip --junk-paths ./Release/rnode_firmware_xiao_esp32s3.zip ./Release/esptool/esptool.py ./Release/console_image.bin build/rnode_firmware_xiao_esp32s3.boot_app0 build/rnode_firmware_xiao_esp32s3.bin build/rnode_firmware_xiao_esp32s3.bootloader build/rnode_firmware_xiao_esp32s3.partitions
+	rm -r build
 
 release-heltec32_v2_extled: check_bt_buffers
 	arduino-cli compile --fqbn esp32:esp32:heltec_wifi_lora_32_V2 $(COMMON_BUILD_FLAGS) --build-property "compiler.cpp.extra_flags=\"-DBOARD_MODEL=0x38\" \"-DEXTERNAL_LEDS=true\""

--- a/Makefile
+++ b/Makefile
@@ -131,6 +131,9 @@ firmware-heltec_w_paper:
 firmware-xiao_s3:
 	arduino-cli compile --fqbn esp32:esp32:XIAO_ESP32S3 $(COMMON_BUILD_FLAGS) --build-property "compiler.cpp.extra_flags=\"-DBOARD_MODEL=0x3E\""
 
+firmware-heltec32_v4:
+	arduino-cli compile --log --fqbn "esp32:esp32:esp32s3:CDCOnBoot=cdc" -e --build-property "build.partitions=no_ota" --build-property "upload.maximum_size=2097152" --build-property "compiler.cpp.extra_flags=\"-DBOARD_MODEL=0x3F\""
+
 firmware-rnode_ng_20: check_bt_buffers
 	arduino-cli compile --fqbn esp32:esp32:ttgo-lora32 $(COMMON_BUILD_FLAGS) --build-property "compiler.cpp.extra_flags=\"-DBOARD_MODEL=0x40\""
 
@@ -214,6 +217,13 @@ upload-xiao_s3:
 	@sleep 3
 	python ./Release/esptool/esptool.py --port $(or $(port), /dev/ttyACM0) --chip esp32-s3 --baud 921600 --before default_reset --after hard_reset write_flash -z --flash_mode dio --flash_freq 80m --flash_size 8MB 0x210000 ./Release/console_image.bin
 
+upload-heltec32_v4:
+	arduino-cli upload -p /dev/ttyACM1 --fqbn esp32:esp32:esp32s3
+	@sleep 1
+	rnodeconf /dev/ttyACM1 --firmware-hash $$(./partition_hashes ./build/esp32.esp32.esp32s3/RNode_Firmware.ino.bin)
+	#@sleep 3
+	#python ./Release/esptool/esptool.py --chip esp32-s3 --port /dev/ttyACM0 --baud 921600 --before default_reset --after hard_reset write_flash -z --flash_mode dio --flash_freq 80m --flash_size 4MB 0x210000 ./Release/console_image.bin
+
 upload-tdeck:
 	arduino-cli upload -p $(or $(port), /dev/ttyACM0) --fqbn esp32:esp32:esp32s3
 	@sleep 1
@@ -277,6 +287,13 @@ upload-techo:
 	arduino-cli upload -p /dev/ttyACM0 --fqbn adafruit:nrf52:pca10056
 	@sleep 6
 	rnodeconf /dev/ttyACM0 --firmware-hash $$(./partition_hashes from_device /dev/ttyACM0)
+
+upload-xiao_s3:
+	arduino-cli upload -p /dev/ttyACM0 --fqbn esp32:esp32:XIAO_ESP32S3
+	@sleep 1
+	rnodeconf /dev/ttyACM0 --firmware-hash $$(./partition_hashes ./build/esp32.esp32.XIAO_ESP32S3/RNode_Firmware_CE.ino.bin)
+	@sleep 3
+	python ./Release/esptool/esptool.py --chip esp32s3 --port /dev/ttyACM0 --baud 921600 --before default_reset --after hard_reset write_flash -z --flash_mode dio --flash_freq 80m --flash_size 4MB 0x210000 ./Release/console_image.bin
 
 release:  console-site spiffs-image $(shell grep ^release- Makefile | cut -d: -f1)
 
@@ -396,6 +413,14 @@ release-xiao_s3:
 	cp build/esp32.esp32.XIAO_ESP32S3/RNode_Firmware_CE.ino.bootloader.bin build/rnode_firmware_xiao_esp32s3.bootloader
 	cp build/esp32.esp32.XIAO_ESP32S3/RNode_Firmware_CE.ino.partitions.bin build/rnode_firmware_xiao_esp32s3.partitions
 	zip --junk-paths ./Release/rnode_firmware_xiao_esp32s3.zip ./Release/esptool/esptool.py ./Release/console_image.bin build/rnode_firmware_xiao_esp32s3.boot_app0 build/rnode_firmware_xiao_esp32s3.bin build/rnode_firmware_xiao_esp32s3.bootloader build/rnode_firmware_xiao_esp32s3.partitions
+
+release-heltec32_v4: check_bt_buffers
+	arduino-cli compile --fqbn esp32:esp32:heltec_wifi_lora_32_V3 -e --build-property "build.partitions=no_ota" --build-property "upload.maximum_size=2097152" --build-property "compiler.cpp.extra_flags=\"-DBOARD_MODEL=0x43\""
+	cp ~/.arduino15/packages/esp32/hardware/esp32/$(ARDUINO_ESP_CORE_VER)/tools/partitions/boot_app0.bin build/rnode_firmware_heltec32v4pa.boot_app0
+	cp build/esp32.esp32.heltec_wifi_lora_32_V3/RNode_Firmware_CE.ino.bin build/rnode_firmware_heltec32v4pa.bin
+	cp build/esp32.esp32.heltec_wifi_lora_32_V3/RNode_Firmware_CE.ino.bootloader.bin build/rnode_firmware_heltec32v4pa.bootloader
+	cp build/esp32.esp32.heltec_wifi_lora_32_V3/RNode_Firmware_CE.ino.partitions.bin build/rnode_firmware_heltec32v4pa.partitions
+	zip --junk-paths ./Release/rnode_firmware_heltec32v4pa.zip ./Release/esptool/esptool.py ./Release/console_image.bin build/rnode_firmware_heltec32v4pa.boot_app0 build/rnode_firmware_heltec32v4pa.bin build/rnode_firmware_heltec32v4pa.bootloader build/rnode_firmware_heltec32v4pa.partitions
 	rm -r build
 
 release-heltec32_v2_extled: check_bt_buffers

--- a/Makefile
+++ b/Makefile
@@ -220,7 +220,7 @@ upload-xiao_s3:
 upload-heltec32_v4:
 	arduino-cli upload -p /dev/ttyACM1 --fqbn esp32:esp32:esp32s3
 	@sleep 1
-	rnodeconf /dev/ttyACM1 --firmware-hash $$(./partition_hashes ./build/esp32.esp32.esp32s3/RNode_Firmware.ino.bin)
+	rnodeconf /dev/ttyACM0 --firmware-hash $$(./partition_hashes ./build/esp32.esp32.esp32s3/RNode_Firmware.ino.bin)
 	#@sleep 3
 	#python ./Release/esptool/esptool.py --chip esp32-s3 --port /dev/ttyACM0 --baud 921600 --before default_reset --after hard_reset write_flash -z --flash_mode dio --flash_freq 80m --flash_size 4MB 0x210000 ./Release/console_image.bin
 

--- a/Makefile
+++ b/Makefile
@@ -221,11 +221,11 @@ upload-xiao_s3:
 	python ./Release/esptool/esptool.py --port $(or $(port), /dev/ttyACM0) --chip esp32-s3 --baud 921600 --before default_reset --after hard_reset write_flash -z --flash_mode dio --flash_freq 80m --flash_size 8MB 0x210000 ./Release/console_image.bin
 
 upload-heltec32_v4:
-	arduino-cli upload -p /dev/ttyACM1 --fqbn esp32:esp32:esp32s3
+	arduino-cli upload -p $(or $(port), /dev/ttyACM0) --fqbn esp32:esp32:esp32s3
 	@sleep 1
-	rnodeconf /dev/ttyACM0 --firmware-hash $$(./partition_hashes ./build/esp32.esp32.esp32s3/RNode_Firmware.ino.bin)
-	#@sleep 3
-	#python ./Release/esptool/esptool.py --chip esp32-s3 --port /dev/ttyACM0 --baud 921600 --before default_reset --after hard_reset write_flash -z --flash_mode dio --flash_freq 80m --flash_size 4MB 0x210000 ./Release/console_image.bin
+	rnodeconf $(or $(port), /dev/ttyACM0) --firmware-hash $$(./partition_hashes ./build/esp32.esp32.esp32s3/RNode_Firmware_CE.ino.bin)
+	@sleep 3
+	python ./Release/esptool/esptool.py --chip esp32-s3 --port $(or $(port), /dev/ttyACM0) --baud 921600 --before default_reset --after hard_reset write_flash -z --flash_mode dio --flash_freq 80m --flash_size 16MB 0x210000 ./Release/console_image.bin
 
 upload-tdeck:
 	arduino-cli upload -p $(or $(port), /dev/ttyACM0) --fqbn esp32:esp32:esp32s3

--- a/Power.h
+++ b/Power.h
@@ -131,6 +131,23 @@
   bool bat_voltage_dropping = false;
   float bat_delay_v = 0;
   float bat_state_change_v = 0;
+#elif BOARD_MODEL == BOARD_HELTEC32_V4
+  #define BAT_V_MIN       3.15
+  #define BAT_V_MAX       4.3
+  #define BAT_V_CHG       4.48
+  #define BAT_V_FLOAT     4.33
+  #define BAT_SAMPLES     7
+  const uint8_t pin_vbat = 1;
+  const uint8_t pin_ctrl = 37;
+  float bat_p_samples[BAT_SAMPLES];
+  float bat_v_samples[BAT_SAMPLES];
+  uint8_t bat_samples_count = 0;
+  int bat_discharging_samples = 0;
+  int bat_charging_samples = 0;
+  int bat_charged_samples = 0;
+  bool bat_voltage_dropping = false;
+  float bat_delay_v = 0;
+  float bat_state_change_v = 0;
 #elif BOARD_MODEL == BOARD_HELTEC_T114
   #define BAT_V_MIN       3.15
   #define BAT_V_MAX       4.165
@@ -174,11 +191,13 @@ uint8_t pmu_rc = 0;
 void kiss_indicate_battery();
 
 void measure_battery() {
-  #if BOARD_MODEL == BOARD_RNODE_NG_21 || BOARD_MODEL == BOARD_LORA32_V2_1 || BOARD_MODEL == BOARD_HELTEC32_V3 || BOARD_MODEL == BOARD_TDECK || BOARD_MODEL == BOARD_T3S3 || BOARD_MODEL == BOARD_HELTEC_T114 || BOARD_MODEL == BOARD_TECHO
+  #if BOARD_MODEL == BOARD_RNODE_NG_21 || BOARD_MODEL == BOARD_LORA32_V2_1 || BOARD_MODEL == BOARD_HELTEC32_V3 || BOARD_MODEL == BOARD_HELTEC32_V4 || BOARD_MODEL == BOARD_TDECK || BOARD_MODEL == BOARD_T3S3 || BOARD_MODEL == BOARD_HELTEC_T114 || BOARD_MODEL == BOARD_TECHO
     battery_installed = true;
     battery_indeterminate = true;
 
     #if BOARD_MODEL == BOARD_HELTEC32_V3
+      float battery_measurement = (float)(analogRead(pin_vbat)) * 0.0041;
+    #elif BOARD_MODEL == BOARD_HELTEC32_V4
       float battery_measurement = (float)(analogRead(pin_vbat)) * 0.0041;
     #elif BOARD_MODEL == BOARD_T3S3
       float battery_measurement = (float)(analogRead(pin_vbat)) / 4095.0*6.7828;
@@ -438,6 +457,10 @@ bool init_pmu() {
     pinMode(pin_vbat, INPUT);
     return true;
   #elif BOARD_MODEL == BOARD_HELTEC32_V3
+    pinMode(pin_ctrl,OUTPUT);
+    digitalWrite(pin_ctrl, LOW);
+    return true;
+  #elif BOARD_MODEL == BOARD_HELTEC32_V4
     pinMode(pin_ctrl,OUTPUT);
     digitalWrite(pin_ctrl, LOW);
     return true;

--- a/RNode_Firmware_CE.ino
+++ b/RNode_Firmware_CE.ino
@@ -179,7 +179,7 @@ void setup() {
     boot_seq();
   #endif
 
-  #if BOARD_MODEL != BOARD_RAK4631 && BOARD_MODEL != BOARD_HELTEC_T114 && BOARD_MODEL != BOARD_TECHO && BOARD_MODEL != BOARD_T3S3 && BOARD_MODEL != BOARD_TBEAM_S_V1 && BOARD_MODEL != BOARD_OPENCOM_XL
+  #if BOARD_MODEL != BOARD_RAK4631 && BOARD_MODEL != BOARD_HELTEC_T114 && BOARD_MODEL != BOARD_TECHO && BOARD_MODEL != BOARD_T3S3 && BOARD_MODEL != BOARD_TBEAM_S_V1 && BOARD_MODEL != BOARD_OPENCOM_XL && BOARD_MODEL != BOARD_HELTEC32_V4
   // Some boards need to wait until the hardware UART is set up before booting
   // the full firmware. In the case of the RAK4631/TECHO, the line below will wait
   // until a serial connection is actually established with a master. Thus, it
@@ -949,6 +949,21 @@ void serial_callback(uint8_t sbyte) {
         kiss_indicate_txpower(selected_radio);
       } else {
         int8_t txp = (int8_t)sbyte;
+        #if MODEM == SX1262
+          #if HAS_LORA_PA
+            if (txp > PA_MAX_OUTPUT) txp = PA_MAX_OUTPUT;
+          #else
+            if (txp > 22) txp = 22;
+          #endif
+        #elif MODEM == SX1280
+          #if HAS_PA
+            if (txp > 20) txp = 20;
+          #else
+            if (txp > 13) txp = 13;
+          #endif
+        #else
+          if (txp > 17) txp = 17;
+        #endif
 
         if (op_mode == MODE_HOST) setTXPower(selected_radio, txp);
         kiss_indicate_txpower(selected_radio);
@@ -1653,6 +1668,12 @@ void sleep_now() {
       #if BOARD_MODEL == BOARD_T3S3 || BOARD_MODEL == BOARD_XIAO_S3
         display_intensity = 0;
         update_display(true);
+      #endif
+      #if BOARD_MODEL == BOARD_HELTEC32_V4
+          digitalWrite(LORA_PA_CPS, LOW);
+          digitalWrite(LORA_PA_CSD, LOW);
+          digitalWrite(LORA_PA_PWR_EN, LOW);
+          digitalWrite(Vext, HIGH);
       #endif
       #if PIN_DISP_SLEEP >= 0
         pinMode(PIN_DISP_SLEEP, OUTPUT);

--- a/Radio.cpp
+++ b/Radio.cpp
@@ -399,6 +399,30 @@ int sx126x::begin()
   setModulationParams(_sf, _bw, _cr, _ldro);
   setPacketParams(_preambleLength, _implicitHeaderMode, _payloadLength, _crcMode);
 
+  #if HAS_LORA_PA
+    #if LORA_PA_GC1109
+      // Enable Vfem_ctl for supply to
+      // PA power net.
+      pinMode(LORA_PA_PWR_EN, OUTPUT);
+      digitalWrite(LORA_PA_PWR_EN, HIGH);
+
+      // Enable PA LNA and TX standby
+      pinMode(LORA_PA_CSD, OUTPUT);
+      digitalWrite(LORA_PA_CSD, HIGH);
+
+      // Keep PA CPS permanently enabled. Toggling it
+      // between TX/RX causes the LNA gain to become
+      // unstable ("wonky"), so it is left on as long
+      // as the radio is powered up.
+      pinMode(LORA_PA_CPS, OUTPUT);
+      digitalWrite(LORA_PA_CPS, HIGH);
+
+      // On Heltec V4, the PA CTX pin is driven by
+      // the SX1262 DIO2 pin directly, so we do not
+      // need to manually raise this.
+    #endif
+  #endif
+
   _radio_online = true;
   return 1;
 }
@@ -511,6 +535,9 @@ int ISR_VECT sx126x::currentRssi() {
     uint8_t byte = 0;
     executeOpcodeRead(OP_CURRENT_RSSI_6X, &byte, 1);
     int rssi = -(int(byte)) / 2;
+    #if HAS_LORA_LNA
+      rssi -= LORA_LNA_GAIN;
+    #endif
     return rssi;
 }
 
@@ -521,10 +548,12 @@ uint8_t sx126x::packetRssiRaw() {
 }
 
 int ISR_VECT sx126x::packetRssi(uint8_t pkt_snr_raw) {
-    // may need more calculations here
     uint8_t buf[3] = {0};
     executeOpcodeRead(OP_PACKET_STATUS_6X, buf, 3);
     int pkt_rssi = -buf[0] / 2;
+    #if HAS_LORA_LNA
+      pkt_rssi -= LORA_LNA_GAIN;
+    #endif
     return pkt_rssi;
 }
 
@@ -712,6 +741,8 @@ void sx126x::enableTCXO() {
     #elif BOARD_MODEL == BOARD_HELTEC_T114
       uint8_t buf[4] = {MODE_TCXO_1_8V_6X, 0x00, 0x00, 0xFF};
     #elif BOARD_MODEL == BOARD_E22_ESP32
+      uint8_t buf[4] = {MODE_TCXO_1_8V_6X, 0x00, 0x00, 0xFF};
+    #elif BOARD_MODEL == BOARD_HELTEC32_V4
       uint8_t buf[4] = {MODE_TCXO_1_8V_6X, 0x00, 0x00, 0xFF};
     #else
       uint8_t buf[4] = {0};

--- a/Radio.cpp
+++ b/Radio.cpp
@@ -601,6 +601,7 @@ uint8_t sx126x::packetRssiRaw() {
 }
 
 int ISR_VECT sx126x::packetRssi(uint8_t pkt_snr_raw) {
+    // may need more calculations here
     uint8_t buf[3] = {0};
     executeOpcodeRead(OP_PACKET_STATUS_6X, buf, 3);
     int pkt_rssi = -buf[0] / 2;

--- a/Radio.cpp
+++ b/Radio.cpp
@@ -16,6 +16,14 @@
   #define ISR_VECT
 #endif
 
+#if HAS_LORA_PA
+  uint8_t lora_pa_model = LORA_PA_MODEL;
+#endif
+
+#if HAS_LORA_LNA
+  int lora_lna_gain = LORA_LNA_GAIN;
+#endif
+
 // SX126x registers
 #define OP_RF_FREQ_6X               0x86
 #define OP_SLEEP_6X                 0x84
@@ -400,7 +408,21 @@ int sx126x::begin()
   setPacketParams(_preambleLength, _implicitHeaderMode, _payloadLength, _crcMode);
 
   #if HAS_LORA_PA
-    #if LORA_PA_GC1109
+    if (lora_pa_model == LORA_PA_UNKNOWN) {
+      #if BOARD_MODEL == BOARD_HELTEC32_V4
+        pinMode(LORA_PA_PWR_EN, OUTPUT);
+        pinMode(LORA_PA_CSD, INPUT);
+        digitalWrite(LORA_PA_PWR_EN, HIGH); delay(5);
+        if (digitalRead(LORA_PA_CSD) == HIGH) {
+          lora_pa_model = LORA_PA_KCT8103L;
+          lora_lna_gain = LORA_LNA_KCT8103L_GAIN;
+        } else {
+          lora_pa_model = LORA_PA_GC1109;
+        }
+      #endif
+    }
+
+    if (lora_pa_model == LORA_PA_GC1109) {
       // Enable Vfem_ctl for supply to
       // PA power net.
       pinMode(LORA_PA_PWR_EN, OUTPUT);
@@ -420,7 +442,26 @@ int sx126x::begin()
       // On Heltec V4, the PA CTX pin is driven by
       // the SX1262 DIO2 pin directly, so we do not
       // need to manually raise this.
-    #endif
+
+    } else if (lora_pa_model == LORA_PA_KCT8103L) {
+      // Enable Vfem_ctl for supply to
+      // PA power net.
+      pinMode(LORA_PA_PWR_EN, OUTPUT);
+      digitalWrite(LORA_PA_PWR_EN, HIGH);
+
+      // Enable KCT8103L chip
+      pinMode(LORA_PA_CSD, OUTPUT);
+      digitalWrite(LORA_PA_CSD, HIGH);
+
+      // Enable receive LNA
+      pinMode(LORA_PA_CTX, OUTPUT);
+      digitalWrite(LORA_PA_CTX, LOW);
+
+      // On Heltec V4.3, the PA CPS pin
+      // is driven by the SX1262 DIO2
+      // pin directly, so we do not
+      // need to manually raise this.
+    }
   #endif
 
   _radio_online = true;
@@ -444,6 +485,18 @@ void sx126x::end()
 
 int sx126x::beginPacket(int implicitHeader)
 {
+  #if HAS_LORA_PA
+    if (lora_pa_model == LORA_PA_GC1109) {
+      // Enable PA CPS for transmit
+      // digitalWrite(LORA_PA_CPS, HIGH);
+      // Disabled since we're keeping it
+      // on permanently as long as the
+      // radio is powered up.
+    } else if (lora_pa_model == LORA_PA_KCT8103L) {
+      digitalWrite(LORA_PA_CTX, HIGH);
+    }
+  #endif
+
   standby();
 
   if (implicitHeader) {
@@ -536,7 +589,7 @@ int ISR_VECT sx126x::currentRssi() {
     executeOpcodeRead(OP_CURRENT_RSSI_6X, &byte, 1);
     int rssi = -(int(byte)) / 2;
     #if HAS_LORA_LNA
-      rssi -= LORA_LNA_GAIN;
+      rssi -= lora_lna_gain;
     #endif
     return rssi;
 }
@@ -552,7 +605,7 @@ int ISR_VECT sx126x::packetRssi(uint8_t pkt_snr_raw) {
     executeOpcodeRead(OP_PACKET_STATUS_6X, buf, 3);
     int pkt_rssi = -buf[0] / 2;
     #if HAS_LORA_LNA
-      pkt_rssi -= LORA_LNA_GAIN;
+      pkt_rssi -= lora_lna_gain;
     #endif
     return pkt_rssi;
 }
@@ -687,6 +740,20 @@ void sx126x::onReceive(void(*callback)(uint8_t, int))
 
 void sx126x::receive(int size)
 {
+    #if HAS_LORA_PA
+      if (lora_pa_model == LORA_PA_GC1109) {
+        // Disable PA CPS for receive
+        // digitalWrite(LORA_PA_CPS, LOW);
+        // That turned out to be a bad idea.
+        // The LNA goes wonky if it's toggled
+        // on and off too quickly. We'll keep
+        // it on permanently, as long as the
+        // radio is powered up.
+      } else if (lora_pa_model == LORA_PA_KCT8103L) {
+        digitalWrite(LORA_PA_CTX, LOW);
+      }
+    #endif
+
     if (size > 0) {
         implicitHeaderMode();
 

--- a/Radio.hpp
+++ b/Radio.hpp
@@ -52,7 +52,9 @@
 #define CSMA_CW_PER_BAND_WINDOWS   15
 #define CSMA_BAND_1_MAX_AIRTIME    7
 #define CSMA_BAND_N_MIN_AIRTIME    85
-#define CSMA_INFR_THRESHOLD_DB     12
+#define CSMA_INFR_THRESHOLD_DB     6
+#define CSMA_RFENV_RECAL_MS        2500
+#define CSMA_RFENV_RECAL_LIMIT_DB -83
 
 #define LED_ID_TRIG 16
 
@@ -98,7 +100,7 @@ public:
     _csma_slot_ms(CSMA_SLOT_MIN_MS),
     _preambleLength(LORA_PREAMBLE_SYMBOLS_MIN), _lora_symbol_time_ms(0.0),
     _lora_preamble_time_ms(0), _lora_header_time_ms(0), _lora_symbol_rate(0.0), _lora_us_per_byte(0.0), _bitrate(0),
-     _packet{0}, _onReceive(NULL), _txp(0), _ldro(false), _limit_rate(false), _interference_detected(false), _avoid_interference(true), _difs_ms(CSMA_SIFS_MS + 2 * _csma_slot_ms), _difs_wait_start(0), _cw_wait_start(0), _cw_wait_target(0), _cw_wait_passed(0), _csma_cw(-1), _cw_band(1), _cw_min(0), _cw_max(CSMA_CW_PER_BAND_WINDOWS), _noise_floor_sampled(false), _noise_floor_sample(0), _noise_floor_buffer({0}), _noise_floor(-292), _led_id_filter(0), _preamble_detected_at(0) {};
+     _packet{0}, _onReceive(NULL), _txp(0), _ldro(false), _limit_rate(false), _interference_detected(false), _interference_persists(false), _interference_start(0), _avoid_interference(true), _difs_ms(CSMA_SIFS_MS + 2 * _csma_slot_ms), _difs_wait_start(0), _cw_wait_start(0), _cw_wait_target(0), _cw_wait_passed(0), _csma_cw(-1), _cw_band(1), _cw_min(0), _cw_max(CSMA_CW_PER_BAND_WINDOWS), _noise_floor_sampled(false), _noise_floor_sample(0), _noise_floor_buffer({0}), _noise_floor(-292), _led_id_filter(0), _preamble_detected_at(0) {};
 
     virtual void reset() = 0;
 
@@ -286,6 +288,19 @@ public:
       if (_interference_detected) { if (_led_id_filter < LED_ID_TRIG) { _led_id_filter += 1; } }
       else                       { if (_led_id_filter > 0) {_led_id_filter -= 1; } }
 
+      // Handle potential false interference detection due to
+      // LNA recalibration, antenna swap, moving into new RF
+      // environment or similar.
+      if (_interference_detected && current_rssi < CSMA_RFENV_RECAL_LIMIT_DB) {
+        if (!_interference_persists) {
+          _interference_persists = true; _interference_start = millis();
+        } else {
+          if (millis()-_interference_start >= CSMA_RFENV_RECAL_MS) { _noise_floor_sampled = false; _interference_persists = false; }
+        }
+      } else {
+        _interference_persists = false;
+      }
+
       if (carrier_detected) { _dcd = true; } else { _dcd = false; }
 
       _dcd_led = _dcd;
@@ -435,6 +450,8 @@ protected:
     bool _ldro;
     bool _limit_rate;
     bool _interference_detected;
+    bool _interference_persists;
+    uint32_t _interference_start;
     bool _avoid_interference;
     int _csma_slot_ms;
     unsigned long _difs_ms;

--- a/Radio.hpp
+++ b/Radio.hpp
@@ -318,6 +318,11 @@ public:
         int current_rssi = currentRssi();
         if (!_dcd) {
             if (!_noise_floor_sampled || current_rssi < _noise_floor + CSMA_INFR_THRESHOLD_DB) {
+                #if HAS_LORA_LNA
+                  // Discard invalid samples due to gain variance
+                  // during LoRa LNA re-calibration
+                  if (current_rssi < _noise_floor-LORA_LNA_GVT) { return; }
+                #endif
                 _noise_floor_buffer[_noise_floor_sample] = current_rssi;
                 _noise_floor_sample = _noise_floor_sample+1;
                 if (_noise_floor_sample >= NOISE_FLOOR_SAMPLES) {

--- a/Radio.hpp
+++ b/Radio.hpp
@@ -58,7 +58,7 @@
 
 #define LED_ID_TRIG 16
 
-#define NOISE_FLOOR_SAMPLES 64
+#define NOISE_FLOOR_SAMPLES 128
 
 #define RSSI_OFFSET 157
 
@@ -284,7 +284,12 @@ public:
         portEXIT_CRITICAL();
       #endif
 
-      _interference_detected = !carrier_detected && (current_rssi > (_noise_floor+CSMA_INFR_THRESHOLD_DB));
+      #if BOARD_MODEL == BOARD_HELTEC32_V4
+        if (_noise_floor > LNA_GD_THRSHLD) { _interference_detected = !carrier_detected && (current_rssi > (_noise_floor+CSMA_INFR_THRESHOLD_DB)); }
+        else                               { _interference_detected = !carrier_detected && (current_rssi > LNA_GD_LIMIT); }
+      #else
+        _interference_detected = !carrier_detected && (current_rssi > (_noise_floor+CSMA_INFR_THRESHOLD_DB));
+      #endif
       if (_interference_detected) { if (_led_id_filter < LED_ID_TRIG) { _led_id_filter += 1; } }
       else                       { if (_led_id_filter > 0) {_led_id_filter -= 1; } }
 
@@ -317,20 +322,26 @@ public:
     void updateNoiseFloor() {
         int current_rssi = currentRssi();
         if (!_dcd) {
+            #if BOARD_MODEL != BOARD_HELTEC32_V4
             if (!_noise_floor_sampled || current_rssi < _noise_floor + CSMA_INFR_THRESHOLD_DB) {
+            #else
+            if ((!_noise_floor_sampled || current_rssi < _noise_floor + CSMA_INFR_THRESHOLD_DB) || (_noise_floor_sampled && (_noise_floor < LNA_GD_THRSHLD && current_rssi <= LNA_GD_LIMIT))) {
+            #endif
                 #if HAS_LORA_LNA
                   // Discard invalid samples due to gain variance
                   // during LoRa LNA re-calibration
                   if (current_rssi < _noise_floor-LORA_LNA_GVT) { return; }
                 #endif
+                bool sum_noise_floor = false;
                 _noise_floor_buffer[_noise_floor_sample] = current_rssi;
                 _noise_floor_sample = _noise_floor_sample+1;
                 if (_noise_floor_sample >= NOISE_FLOOR_SAMPLES) {
                     _noise_floor_sample %= NOISE_FLOOR_SAMPLES;
                     _noise_floor_sampled = true;
+                    sum_noise_floor = true;
                 }
 
-                if (_noise_floor_sampled) {
+                if (_noise_floor_sampled && sum_noise_floor) {
                     _noise_floor = 0;
                     for (int ni = 0; ni < NOISE_FLOOR_SAMPLES; ni++) { _noise_floor += _noise_floor_buffer[ni]; }
                     _noise_floor /= NOISE_FLOOR_SAMPLES;

--- a/Utilities.h
+++ b/Utilities.h
@@ -1222,11 +1222,31 @@ void set_implicit_length(uint8_t len) {
 }
 
 #if HAS_LORA_PA
-	const int tx_gain[PA_GAIN_POINTS] = {PA_GAIN_VALUES};
+	#if BOARD_MODEL == BOARD_HELTEC32_V4
+		bool pa_values_determined = false;
+		int tx_gain[PA_GAIN_POINTS] = {100};
+	#else
+		bool pa_values_determined = true;
+		const int tx_gain[PA_GAIN_POINTS] = {PA_GAIN_VALUES};
+	#endif
 #endif
+
+extern uint8_t lora_pa_model;
+void determine_pa_values() {
+	#if BOARD_MODEL == BOARD_HELTEC32_V4
+		if (lora_pa_model == LORA_PA_GC1109) {
+			for (int i=0; i < PA_GAIN_POINTS; i++) { tx_gain[i] = PA_GC1109_VALUES[i]; }
+			pa_values_determined = true;
+		} else if (lora_pa_model == LORA_PA_KCT8103L) {
+			for (int i=0; i < PA_GAIN_POINTS; i++) { tx_gain[i] = PA_KCT8103L_VALUES[i]; }
+			pa_values_determined = true;
+		}
+	#endif
+}
 
 int map_target_power_to_modem_output(int target_tx_power) {
 	#if HAS_LORA_PA
+		if (!pa_values_determined) { determine_pa_values(); }
 		int modem_output_dbm = -9;
 		for (int i = 0; i < PA_GAIN_POINTS; i++) {
 			int gain = tx_gain[i];

--- a/Utilities.h
+++ b/Utilities.h
@@ -1630,7 +1630,7 @@ bool eeprom_model_valid() {
 	#elif BOARD_MODEL == BOARD_HELTEC32_V3
 	if (model == MODEL_C5 || model == MODEL_CA) {
     #elif BOARD_MODEL == BOARD_HELTEC32_V4
-    if (model == MODEL_C8) {
+    if (model == MODEL_C8 || model == MODEL_CC) {
     #elif BOARD_MODEL == BOARD_H_W_PAPER
     if (model == MODEL_C8) {
     #elif BOARD_MODEL == BOARD_HELTEC_T114

--- a/Utilities.h
+++ b/Utilities.h
@@ -72,7 +72,7 @@ uint8_t eeprom_read(uint32_t mapped_addr);
 #if MCU_VARIANT == MCU_ESP32
   #if BOARD_MODEL == BOARD_HELTEC32_V3
     //https://github.com/espressif/esp-idf/issues/8855
-  	#include "hal/wdt_hal.h"
+    #include "hal/wdt_hal.h"
 	#elif BOARD_MODEL == BOARD_T3S3
 		#include "hal/wdt_hal.h"
   #else

--- a/Utilities.h
+++ b/Utilities.h
@@ -70,9 +70,9 @@ uint8_t eeprom_read(uint32_t mapped_addr);
 	#include "Device.h"
 #endif
 #if MCU_VARIANT == MCU_ESP32
-  //https://github.com/espressif/esp-idf/issues/8855
   #if BOARD_MODEL == BOARD_HELTEC32_V3
-    #include "hal/wdt_hal.h"
+    //https://github.com/espressif/esp-idf/issues/8855
+  	#include "hal/wdt_hal.h"
 	#elif BOARD_MODEL == BOARD_T3S3
 		#include "hal/wdt_hal.h"
   #else

--- a/Utilities.h
+++ b/Utilities.h
@@ -1221,10 +1221,55 @@ void set_implicit_length(uint8_t len) {
 	}
 }
 
+#if HAS_LORA_PA
+	const int tx_gain[PA_GAIN_POINTS] = {PA_GAIN_VALUES};
+#endif
+
+int map_target_power_to_modem_output(int target_tx_power) {
+	#if HAS_LORA_PA
+		int modem_output_dbm = -9;
+		for (int i = 0; i < PA_GAIN_POINTS; i++) {
+			int gain = tx_gain[i];
+			int effective_output_dbm = i + gain;
+			if (effective_output_dbm > target_tx_power) {
+				int diff = effective_output_dbm - target_tx_power;
+				modem_output_dbm = -1*diff;
+				break;
+			} else if (effective_output_dbm == target_tx_power) {
+				modem_output_dbm = i; break;
+			} else if (i == PA_GAIN_POINTS-1) {
+				int diff = target_tx_power - effective_output_dbm;
+				modem_output_dbm = i+diff; break;
+			}
+		}
+	#else
+		int modem_output_dbm = target_tx_power;
+	#endif
+
+	return modem_output_dbm;
+}
+
+int map_modem_output_to_target_power(int modem_output_dbm) {
+	#if HAS_LORA_PA
+		if (modem_output_dbm < 0)               { modem_output_dbm = 0; }
+		if (modem_output_dbm >= PA_GAIN_POINTS) { modem_output_dbm = PA_GAIN_POINTS-1; }
+		int gain = tx_gain[modem_output_dbm];
+		int target_tx_power = modem_output_dbm+gain;
+	#else
+		int target_tx_power = modem_output_dbm;
+	#endif
+
+	return target_tx_power;
+}
+
 void setTXPower(RadioInterface* radio, int txp) {
     // Todo, revamp this function. The current parameters for setTxPower are
     // suboptimal, as some chips have power amplifiers which means that the max
     // dBm is not always the same.
+    #if HAS_LORA_PA
+        txp = map_target_power_to_modem_output(txp);
+    #endif
+
     if (model == MODEL_12) {
         if (interfaces[radio->getIndex()] == SX1280) {
             radio->setTxPower(txp, PA_OUTPUT_PA_BOOST_PIN);
@@ -1276,6 +1321,7 @@ void setTXPower(RadioInterface* radio, int txp) {
     if (model == MODEL_C6) radio->setTxPower(txp, PA_OUTPUT_RFO_PIN);
     if (model == MODEL_C7) radio->setTxPower(txp, PA_OUTPUT_RFO_PIN);
     if (model == MODEL_CA) radio->setTxPower(txp, PA_OUTPUT_PA_BOOST_PIN);
+    if (model == MODEL_C8) radio->setTxPower(txp, PA_OUTPUT_PA_BOOST_PIN);
 
     if (model == MODEL_D4) radio->setTxPower(txp, PA_OUTPUT_PA_BOOST_PIN);
     if (model == MODEL_D9) radio->setTxPower(txp, PA_OUTPUT_PA_BOOST_PIN);
@@ -1515,7 +1561,7 @@ bool eeprom_product_valid() {
   #endif
 
 	#if PLATFORM == PLATFORM_ESP32
-	if (rval == PRODUCT_RNODE || rval == BOARD_RNODE_NG_20 || rval == BOARD_RNODE_NG_21 || rval == PRODUCT_HMBRW || rval == PRODUCT_TBEAM || rval == PRODUCT_T32_10 || rval == PRODUCT_T32_20 || rval == PRODUCT_T32_21 || rval == PRODUCT_H32_V2 || rval == PRODUCT_H32_V3 || rval == PRODUCT_TDECK_V1 || rval == PRODUCT_TBEAM_S_V1 || rval == PRODUCT_H_W_PAPER || rval == PRODUCT_XIAO_S3) {
+	if (rval == PRODUCT_RNODE || rval == BOARD_RNODE_NG_20 || rval == BOARD_RNODE_NG_21 || rval == PRODUCT_HMBRW || rval == PRODUCT_TBEAM || rval == PRODUCT_T32_10 || rval == PRODUCT_T32_20 || rval == PRODUCT_T32_21 || rval == PRODUCT_H32_V2 || rval == PRODUCT_H32_V3 || rval == PRODUCT_H32_V4 || rval == PRODUCT_TDECK_V1 || rval == PRODUCT_TBEAM_S_V1 || rval == PRODUCT_H_W_PAPER || rval == PRODUCT_XIAO_S3) {
 	#elif PLATFORM == PLATFORM_NRF52
 	if (rval == PRODUCT_RAK4631 || rval == PRODUCT_HELTEC_T114 || rval == PRODUCT_OPENCOM_XL || rval == PRODUCT_TECHO || rval == PRODUCT_HMBRW) {
 	#else

--- a/Utilities.h
+++ b/Utilities.h
@@ -70,8 +70,8 @@ uint8_t eeprom_read(uint32_t mapped_addr);
 	#include "Device.h"
 #endif
 #if MCU_VARIANT == MCU_ESP32
+  //https://github.com/espressif/esp-idf/issues/8855
   #if BOARD_MODEL == BOARD_HELTEC32_V3
-    //https://github.com/espressif/esp-idf/issues/8855
     #include "hal/wdt_hal.h"
 	#elif BOARD_MODEL == BOARD_T3S3
 		#include "hal/wdt_hal.h"
@@ -288,7 +288,7 @@ uint8_t boot_vector = 0x00;
 			void led_tx_off() { digitalWrite(pin_led_tx, LOW); }
 			void led_id_on()  { }
 			void led_id_off() { }
-	#elif BOARD_MODEL == BOARD_H_W_PAPER
+	#elif BOARD_MODEL == BOARD_H_W_PAPER || BOARD_MODEL == BOARD_HELTEC32_V4
 			void led_rx_on()  { digitalWrite(pin_led_rx, HIGH); }
 			void led_rx_off() {	digitalWrite(pin_led_rx, LOW); }
 			void led_tx_on()  { digitalWrite(pin_led_tx, HIGH); }
@@ -1563,6 +1563,8 @@ bool eeprom_model_valid() {
 	if (model == MODEL_C4 || model == MODEL_C9) {
 	#elif BOARD_MODEL == BOARD_HELTEC32_V3
 	if (model == MODEL_C5 || model == MODEL_CA) {
+    #elif BOARD_MODEL == BOARD_HELTEC32_V4
+    if (model == MODEL_C8) {
     #elif BOARD_MODEL == BOARD_H_W_PAPER
     if (model == MODEL_C8) {
     #elif BOARD_MODEL == BOARD_HELTEC_T114


### PR DESCRIPTION
This is a cherry pick of Mark's support for the HeltecV4.  I opted not to try to bring in all of the changes on the original repository in favor of keeping this smaller.  I also added support for the R8 version of the Heltec V4 because it's got a different pin to run the OLED.

Also fixed a few stray bugs, added some more uniform constants to the makefile, and reorganized a bit so that all the heltec definitions were near each other.

Update: I removed the reorganization after reading some of the commentary on other PR's.

Update 2: this does not include wifi support for the heltec-v4.  I'm working on that, will add to a subsequent PR.