### PR TITLE
Add support for MiniMesh Lite (SH1106 OLED and correct EEPROM validat…

### DIFF
--- a/Boards.h
+++ b/Boards.h
@@ -1201,7 +1201,9 @@
     #elif BOARD_MODEL == BOARD_MINIMESH_LITE || BOARD_MODEL == BOARD_MICROMESH
       #define HAS_EEPROM false
       #define HAS_DISPLAY true
-      #define DISPLAY MONO_OLED
+      #ifndef DISPLAY
+        #define DISPLAY MONO_OLED
+      #endif
       #define HAS_BLUETOOTH false
       #define HAS_BLE true
       #define HAS_CONSOLE false

--- a/Boards.h
+++ b/Boards.h
@@ -123,6 +123,14 @@
   #define MODEL_16            0x16 // T-Echo 433 MHz
   #define MODEL_17            0x17 // T-Echo 868/915 MHz
 
+  #define PRODUCT_DEEPLAB     0x60 // Deeplab Studio
+  #define BOARD_MINIMESH_LITE 0x61
+  #define BOARD_MICROMESH     0x62
+  #define MODEL_52            0x52 // MiniMesh Lite 433 MHz
+  #define MODEL_62            84 // MiniMesh Lite 868 MHz (Decimal 84)
+  #define MODEL_53            0x53 // MicroMesh 433 MHz
+  #define MODEL_64            85 // MicroMesh 868 MHz (Decimal 85)
+
   #define PRODUCT_HMBRW       0xF0
   #define BOARD_HMBRW         0x32
   #define BOARD_HUZZAH32      0x34
@@ -1189,6 +1197,69 @@
       #define PIN_VEXT_EN _PINNUM(0, 12)
       const int pin_led_rx = PIN_LED_BLUE;
       const int pin_led_tx = PIN_LED_RED;
+
+    #elif BOARD_MODEL == BOARD_MINIMESH_LITE || BOARD_MODEL == BOARD_MICROMESH
+      #define HAS_EEPROM false
+      #define HAS_DISPLAY true
+      #define DISPLAY MONO_OLED
+      #define HAS_BLUETOOTH false
+      #define HAS_BLE true
+      #define HAS_CONSOLE false
+      #define HAS_PMU false
+      #define HAS_NP false
+      #define HAS_SD false
+      #define CONFIG_UART_BUFFER_SIZE 6144
+      #define CONFIG_QUEUE_0_SIZE 6144
+      #define HAS_INPUT true
+      #define CONFIG_QUEUE_MAX_LENGTH 200
+      #define EEPROM_SIZE 296
+      #define EEPROM_OFFSET EEPROM_SIZE-EEPROM_RESERVED
+      
+      #define BLE_MANUFACTURER "Deeplab Studio"
+      #if BOARD_MODEL == BOARD_MINIMESH_LITE
+        #define BLE_MODEL "MiniMesh Lite"
+      #else
+        #define BLE_MODEL "MicroMesh"
+      #endif
+
+      #define INTERFACE_COUNT 1
+
+      const uint8_t interfaces[INTERFACE_COUNT] = {SX1262};
+      const bool interface_cfg[INTERFACE_COUNT][3] = { 
+          {
+              false, // DEFAULT_SPI
+              false, // HAS_TCXO
+              true   // DIO2_AS_RF_SWITCH
+          }
+      };
+
+      const int8_t interface_pins[INTERFACE_COUNT][10] = { 
+          {
+              45, // pin_ss
+              43, // pin_sclk
+              47, // pin_mosi
+               2, // pin_miso
+              29, // pin_busy
+              10, // pin_dio
+               9, // pin_reset
+              -1, // pin_txen
+              17, // pin_rxen
+              -1  // pin_tcxo_enable
+          }
+      };
+
+
+
+      const int pin_led_rx = 33; // Dummy pin to prevent crash
+      const int pin_led_tx = 34; // Dummy pin to prevent crash
+      const int pin_btn_usr1 = 32;
+
+      #define I2C_SCL 11
+      #define I2C_SDA 36
+      
+      #define PIN_GPS_RX 20
+      #define PIN_GPS_TX 22
+      #define PIN_GPS_EN 24
 
     #elif BOARD_MODEL == BOARD_RAK4631 || BOARD_MODEL == BOARD_OPENCOM_XL
       #define HAS_EEPROM false

--- a/Display.h
+++ b/Display.h
@@ -98,7 +98,7 @@ void busyCallback(const void* p) { display_callback(); }
   #define SDA_OLED 18
   #endif
 #elif BOARD_MODEL == BOARD_MINIMESH_LITE || BOARD_MODEL == BOARD_MICROMESH
-  #if DISPLAY == MONO_OLED
+  #if DISPLAY == MONO_OLED || DISPLAY == OLED
   #define DISP_RST -1
   #define DISP_ADDR 0x3C
   #define SCL_OLED 11

--- a/Display.h
+++ b/Display.h
@@ -97,6 +97,13 @@ void busyCallback(const void* p) { display_callback(); }
   #define SCL_OLED 17
   #define SDA_OLED 18
   #endif
+#elif BOARD_MODEL == BOARD_MINIMESH_LITE || BOARD_MODEL == BOARD_MICROMESH
+  #if DISPLAY == MONO_OLED
+  #define DISP_RST -1
+  #define DISP_ADDR 0x3C
+  #define SCL_OLED 11
+  #define SDA_OLED 36 // P1.04 = 32+4 = 36
+  #endif
 #elif BOARD_MODEL == BOARD_RAK4631 || BOARD_MODEL == BOARD_OPENCOM_XL
   #if DISPLAY == OLED
   // RAK1921/SSD1306
@@ -170,8 +177,8 @@ uint32_t last_epd_full_refresh = 0;
     Adafruit_SSD1306 display(DISP_W, DISP_H, &Wire, DISP_RST);
   #elif BOARD_MODEL == BOARD_TDECK
     Adafruit_ST7789 display = Adafruit_ST7789(DISPLAY_CS, DISPLAY_DC, -1);
-  #elif BOARD_MODEL == BOARD_TBEAM_S_V1
-    Adafruit_SH1106G display = Adafruit_SH1106G(DISP_W, DISP_H, &Wire, -1);
+  #elif BOARD_MODEL == BOARD_TBEAM_S_V1 || BOARD_MODEL == BOARD_MINIMESH_LITE || BOARD_MODEL == BOARD_MICROMESH
+    Adafruit_SH1106G display = Adafruit_SH1106G(DISP_W, DISP_H, &Wire, DISP_RST);
   #elif BOARD_MODEL == BOARD_HELTEC_T114
     ST7789Spi display(&SPI1, DISPLAY_RST, DISPLAY_DC, DISPLAY_CS);
   #endif
@@ -273,7 +280,7 @@ void update_area_positions() {
 }
 
 uint8_t display_contrast = 0x00;
-#if BOARD_MODEL == BOARD_TBEAM_S_V1
+#if BOARD_MODEL == BOARD_TBEAM_S_V1 || BOARD_MODEL == BOARD_MINIMESH_LITE || BOARD_MODEL == BOARD_MICROMESH
   void set_contrast(Adafruit_SH1106G *display, uint8_t value) {
   }
 #elif BOARD_MODEL == BOARD_HELTEC_T114
@@ -379,6 +386,9 @@ bool display_init() {
       Wire.begin(SDA_OLED, SCL_OLED);
     #elif BOARD_MODEL == BOARD_XIAO_S3
       Wire.begin(SDA_OLED, SCL_OLED);
+    #elif BOARD_MODEL == BOARD_MINIMESH_LITE || BOARD_MODEL == BOARD_MICROMESH
+      Wire.setPins(SDA_OLED, SCL_OLED);
+      Wire.begin();
     #endif
 
     #if HAS_EEPROM
@@ -431,14 +441,14 @@ bool display_init() {
     // set white as default pixel colour for Heltec T114
     display.setRGB(COLOR565(0xFF, 0xFF, 0xFF));
     if (false) {
-    #elif BOARD_MODEL == BOARD_TBEAM_S_V1
+    #elif BOARD_MODEL == BOARD_TBEAM_S_V1 || BOARD_MODEL == BOARD_MINIMESH_LITE || BOARD_MODEL == BOARD_MICROMESH
     if (!display.begin(display_address, true)) {
     #else
     if (!display.begin(SSD1306_SWITCHCAPVCC, display_address)) {
     #endif
       return false;
     } else {
-      #if DISPLAY == OLED
+      #if DISPLAY == OLED || DISPLAY == MONO_OLED
         set_contrast(&display, display_contrast);
       #endif
       if (display_rotation != 0xFF) {
@@ -485,6 +495,9 @@ bool display_init() {
             disp_mode = DISP_MODE_PORTRAIT;
             display.setRotation(1);
           #elif BOARD_MODEL == BOARD_RAK4631 || BOARD_MODEL == BOARD_OPENCOM_XL
+            disp_mode = DISP_MODE_LANDSCAPE;
+            display.setRotation(0);
+          #elif BOARD_MODEL == BOARD_MINIMESH_LITE || BOARD_MODEL == BOARD_MICROMESH
             disp_mode = DISP_MODE_LANDSCAPE;
             display.setRotation(0);
           #elif BOARD_MODEL == BOARD_TDECK
@@ -1068,9 +1081,9 @@ void update_disp_area() {
 }
 
 void display_recondition() {
-  #if DISPLAY == OLED
+  #if DISPLAY == OLED || DISPLAY == MONO_OLED
     for (uint8_t iy = 0; iy < disp_area.height(); iy++) {
-      unsigned char rand_seg [] = {random(0xFF),random(0xFF),random(0xFF),random(0xFF),random(0xFF),random(0xFF),random(0xFF),random(0xFF)};
+      unsigned char rand_seg [] = {(unsigned char)random(0xFF),(unsigned char)random(0xFF),(unsigned char)random(0xFF),(unsigned char)random(0xFF),(unsigned char)random(0xFF),(unsigned char)random(0xFF),(unsigned char)random(0xFF),(unsigned char)random(0xFF)};
       stat_area.drawBitmap(0, iy, rand_seg, 64, 1, DISPLAY_WHITE, DISPLAY_BLACK);
       disp_area.drawBitmap(0, iy, rand_seg, 64, 1, DISPLAY_WHITE, DISPLAY_BLACK);
     }

--- a/Makefile
+++ b/Makefile
@@ -152,7 +152,14 @@ firmware-rak4631_sx1280:
 firmware-opencom-xl:
 	arduino-cli compile --fqbn rakwireless:nrf52:WisCoreRAK4631Board $(COMMON_BUILD_FLAGS) --build-property "compiler.cpp.extra_flags=\"-DBOARD_MODEL=0x52\" \"-DBOARD_VARIANT=0x21\""
 
+firmware-minimesh_lite:
+	arduino-cli compile --log --fqbn adafruit:nrf52:pca10056 -e --build-property "compiler.cpp.extra_flags=\"-DBOARD_MODEL=0x61\""
+
+firmware-micromesh:
+	arduino-cli compile --log --fqbn adafruit:nrf52:pca10056 -e --build-property "compiler.cpp.extra_flags=\"-DBOARD_MODEL=0x62\""
+
 firmware-heltec_t114:
+	python3 ./Scripts/heltec_nrf52_bsp_prep.py
 	arduino-cli compile --log --fqbn Heltec_nRF52:Heltec_nRF52:HT-n5262 -e --build-property "build.partitions=no_ota" --build-property "upload.maximum_size=2097152" --build-property "compiler.cpp.extra_flags=\"-DBOARD_MODEL=0x3C\""
 
 firmware-heltec_t114_gps:
@@ -256,9 +263,16 @@ upload-featheresp32:
 	@sleep 3
 	python ./Release/esptool/esptool.py --port $(or $(port), /dev/ttyUSB0) $(COMMON_UPLOAD_FLAGS) ./Release/console_image.bin
 
+upload-minimesh_lite upload-micromesh:
+	arduino-cli upload -p $(or $(port), /dev/ttyACM0) --fqbn adafruit:nrf52:pca10056
+	unzip -o build/adafruit.nrf52.pca10056/RNode_Firmware_CE.ino.zip -d build/adafruit.nrf52.pca10056
+	@sleep 3
+	rnodeconf $(or $(port), /dev/ttyACM0) --firmware-hash $$(sha256sum ./build/adafruit.nrf52.pca10056/RNode_Firmware_CE.ino.bin | grep -o '^\S*')
+
 upload-opencom-xl upload-rak4631:
 	arduino-cli upload -p $(or $(port), /dev/ttyACM0) --fqbn rakwireless:nrf52:WisCoreRAK4631Board
 	unzip -o build/rakwireless.nrf52.WisCoreRAK4631Board/RNode_Firmware_CE.ino.zip -d build/rakwireless.nrf52.WisCoreRAK4631Board
+	@sleep 3
 	rnodeconf $(or $(port), /dev/ttyACM0) --firmware-hash $$(sha256sum ./build/rakwireless.nrf52.WisCoreRAK4631Board/RNode_Firmware_CE.ino.bin | grep -o '^\S*')
 
 upload-e22_esp32:
@@ -521,6 +535,16 @@ release-opencom-xl:
 	arduino-cli compile --fqbn rakwireless:nrf52:WisCoreRAK4631Board $(COMMON_BUILD_FLAGS) --build-property "compiler.cpp.extra_flags=\"-DBOARD_MODEL=0x52\" \"-DBOARD_VARIANT=0x21\""
 	cp build/rakwireless.nrf52.WisCoreRAK4631Board/RNode_Firmware_CE.ino.hex build/rnode_firmware_opencom_xl.hex
 	adafruit-nrfutil dfu genpkg --dev-type 0x0052 --application build/rnode_firmware_opencom_xl.hex Release/rnode_firmware_opencom_xl.zip
+
+release-minimesh_lite:
+	arduino-cli compile --fqbn rakwireless:nrf52:WisCoreRAK4631Board $(COMMON_BUILD_FLAGS) --build-property "compiler.cpp.extra_flags=\"-DBOARD_MODEL=0x61\""
+	cp build/rakwireless.nrf52.WisCoreRAK4631Board/RNode_Firmware_CE.ino.hex build/rnode_firmware_minimesh_lite.hex
+	adafruit-nrfutil dfu genpkg --dev-type 0x0052 --application build/rnode_firmware_minimesh_lite.hex Release/rnode_firmware_minimesh_lite.zip
+
+release-micromesh:
+	arduino-cli compile --fqbn rakwireless:nrf52:WisCoreRAK4631Board $(COMMON_BUILD_FLAGS) --build-property "compiler.cpp.extra_flags=\"-DBOARD_MODEL=0x62\""
+	cp build/rakwireless.nrf52.WisCoreRAK4631Board/RNode_Firmware_CE.ino.hex build/rnode_firmware_micromesh.hex
+	adafruit-nrfutil dfu genpkg --dev-type 0x0052 --application build/rnode_firmware_micromesh.hex Release/rnode_firmware_micromesh.zip
 	rm -r build
 
 release-heltec_t114:

--- a/Makefile
+++ b/Makefile
@@ -153,10 +153,10 @@ firmware-opencom-xl:
 	arduino-cli compile --fqbn rakwireless:nrf52:WisCoreRAK4631Board $(COMMON_BUILD_FLAGS) --build-property "compiler.cpp.extra_flags=\"-DBOARD_MODEL=0x52\" \"-DBOARD_VARIANT=0x21\""
 
 firmware-minimesh_lite:
-	arduino-cli compile --log --fqbn adafruit:nrf52:pca10056 -e --build-property "compiler.cpp.extra_flags=\"-DBOARD_MODEL=0x61\""
+	arduino-cli compile --log --fqbn adafruit:nrf52:pca10056 -e --build-property "compiler.cpp.extra_flags=\"-DBOARD_MODEL=0x61 $(EXTRA_FLAGS)\""
 
 firmware-micromesh:
-	arduino-cli compile --log --fqbn adafruit:nrf52:pca10056 -e --build-property "compiler.cpp.extra_flags=\"-DBOARD_MODEL=0x62\""
+	arduino-cli compile --log --fqbn adafruit:nrf52:pca10056 -e --build-property "compiler.cpp.extra_flags=\"-DBOARD_MODEL=0x62 $(EXTRA_FLAGS)\""
 
 firmware-heltec_t114:
 	python3 ./Scripts/heltec_nrf52_bsp_prep.py

--- a/Power.h
+++ b/Power.h
@@ -62,6 +62,26 @@
   bool bat_voltage_dropping = false;
   float bat_delay_v = 0;
   float bat_state_change_v = 0;
+#elif BOARD_MODEL == BOARD_MINIMESH_LITE || BOARD_MODEL == BOARD_MICROMESH
+  #include "nrfx_power.h"
+  #define BAT_C_SAMPLES   7
+  #define BAT_D_SAMPLES   2
+  #define BAT_V_MIN       3.15
+  #define BAT_V_MAX       4.2
+  #define BAT_V_FLOAT     4.22
+  #define BAT_SAMPLES     5
+  #define VBAT_MV_PER_LSB (0.73242188F)
+  #define VBAT_DIVIDER_COMP (1.66666666F)
+  #define VBAT_MV_PER_LSB_FIN (VBAT_DIVIDER_COMP * VBAT_MV_PER_LSB)
+  #define PIN_VBAT 31
+  float bat_p_samples[BAT_SAMPLES];
+  float bat_v_samples[BAT_SAMPLES];
+  uint8_t bat_samples_count = 0;
+  int bat_discharging_samples = 0;
+  int bat_charging_samples = 0;
+  int bat_charged_samples = 0;
+  bool bat_voltage_dropping = false;
+  float bat_delay_v = 0;
 #elif BOARD_MODEL == BOARD_RAK4631 || BOARD_MODEL == BOARD_OPENCOM_XL
   #include "nrfx_power.h"
   #define BAT_C_SAMPLES   7

--- a/RNode_Firmware_CE.ino
+++ b/RNode_Firmware_CE.ino
@@ -18,7 +18,7 @@
 #include "Utilities.h"
 
 #if MCU_VARIANT == MCU_NRF52
-  #if BOARD_MODEL == BOARD_RAK4631 || BOARD_MODEL == BOARD_OPENCOM_XL
+  #if BOARD_MODEL == BOARD_RAK4631 || BOARD_MODEL == BOARD_OPENCOM_XL || BOARD_MODEL == BOARD_MINIMESH_LITE || BOARD_MODEL == BOARD_MICROMESH
       #define INTERFACE_SPI
         // Required because on RAK4631, non-default SPI pins must be initialised when class is declared.
       SPIClass interface_spi[1] = {
@@ -179,7 +179,7 @@ void setup() {
     boot_seq();
   #endif
 
-  #if BOARD_MODEL != BOARD_RAK4631 && BOARD_MODEL != BOARD_HELTEC_T114 && BOARD_MODEL != BOARD_TECHO && BOARD_MODEL != BOARD_T3S3 && BOARD_MODEL != BOARD_TBEAM_S_V1 && BOARD_MODEL != BOARD_OPENCOM_XL
+  #if BOARD_MODEL != BOARD_RAK4631 && BOARD_MODEL != BOARD_HELTEC_T114 && BOARD_MODEL != BOARD_TECHO && BOARD_MODEL != BOARD_T3S3 && BOARD_MODEL != BOARD_TBEAM_S_V1 && BOARD_MODEL != BOARD_OPENCOM_XL && BOARD_MODEL != BOARD_MINIMESH_LITE && BOARD_MODEL != BOARD_MICROMESH
   // Some boards need to wait until the hardware UART is set up before booting
   // the full firmware. In the case of the RAK4631/TECHO, the line below will wait
   // until a serial connection is actually established with a master. Thus, it
@@ -1580,7 +1580,7 @@ void loop() {
   process_serial();
 
   #if HAS_DISPLAY
-    #if DISPLAY == OLED || DISPLAY == TFT || DISPLAY == ADAFRUIT_TFT
+    #if DISPLAY == OLED || DISPLAY == MONO_OLED || DISPLAY == TFT || DISPLAY == ADAFRUIT_TFT
     if (disp_ready) update_display();
     #elif DISPLAY == EINK_BW || DISPLAY == EINK_3C
     // Display refreshes take so long on e-paper displays that they can disrupt

--- a/Radio.cpp
+++ b/Radio.cpp
@@ -121,6 +121,9 @@ bool sx126x::preInit() {
     _spiModem->begin();
   }
   #else
+    #if BOARD_MODEL == BOARD_MINIMESH_LITE || BOARD_MODEL == BOARD_MICROMESH
+      _spiModem->setPins(_miso, _sclk, _mosi);
+    #endif
     _spiModem->begin();
   #endif
 

--- a/Utilities.h
+++ b/Utilities.h
@@ -339,6 +339,13 @@ uint8_t boot_vector = 0x00;
       void led_tx_off() { npset(0, 0, 0); }
       void led_id_on()  { npset(0x90, 0, 0x70); }
       void led_id_off() { npset(0, 0, 0); }
+    #elif BOARD_MODEL == BOARD_MINIMESH_LITE || BOARD_MODEL == BOARD_MICROMESH
+		void led_rx_on()  { }
+		void led_rx_off() {	}
+		void led_tx_on()  { }
+		void led_tx_off() { }
+		void led_id_on()  { }
+		void led_id_off() { }
     #elif BOARD_MODEL == BOARD_RAK4631 || BOARD_MODEL == BOARD_OPENCOM_XL
 		void led_rx_on()  { digitalWrite(pin_led_rx, HIGH); }
 		void led_rx_off() {	digitalWrite(pin_led_rx, LOW); }
@@ -1270,9 +1277,11 @@ void setTXPower(RadioInterface* radio, int txp) {
     if (model == MODEL_BA) radio->setTxPower(txp, PA_OUTPUT_PA_BOOST_PIN);
     if (model == MODEL_BB) radio->setTxPower(txp, PA_OUTPUT_PA_BOOST_PIN);
 
-    if (model == MODEL_C4) radio->setTxPower(txp, PA_OUTPUT_PA_BOOST_PIN);
-    if (model == MODEL_C9) radio->setTxPower(txp, PA_OUTPUT_PA_BOOST_PIN);
-    if (model == MODEL_C5) radio->setTxPower(txp, PA_OUTPUT_PA_BOOST_PIN);
+    		if (model == MODEL_C5) radio->setTxPower(txp, PA_OUTPUT_PA_BOOST_PIN);
+		if (model == MODEL_CA) radio->setTxPower(txp, PA_OUTPUT_PA_BOOST_PIN);
+		if (model == MODEL_C8) radio->setTxPower(txp, PA_OUTPUT_PA_BOOST_PIN);
+
+		if (model == MODEL_52 || model == MODEL_62 || model == MODEL_53 || model == MODEL_64) radio->setTxPower(txp, PA_OUTPUT_PA_BOOST_PIN);
     if (model == MODEL_C6) radio->setTxPower(txp, PA_OUTPUT_RFO_PIN);
     if (model == MODEL_C7) radio->setTxPower(txp, PA_OUTPUT_RFO_PIN);
     if (model == MODEL_CA) radio->setTxPower(txp, PA_OUTPUT_PA_BOOST_PIN);
@@ -1517,7 +1526,7 @@ bool eeprom_product_valid() {
 	#if PLATFORM == PLATFORM_ESP32
 	if (rval == PRODUCT_RNODE || rval == BOARD_RNODE_NG_20 || rval == BOARD_RNODE_NG_21 || rval == PRODUCT_HMBRW || rval == PRODUCT_TBEAM || rval == PRODUCT_T32_10 || rval == PRODUCT_T32_20 || rval == PRODUCT_T32_21 || rval == PRODUCT_H32_V2 || rval == PRODUCT_H32_V3 || rval == PRODUCT_TDECK_V1 || rval == PRODUCT_TBEAM_S_V1 || rval == PRODUCT_H_W_PAPER || rval == PRODUCT_XIAO_S3) {
 	#elif PLATFORM == PLATFORM_NRF52
-	if (rval == PRODUCT_RAK4631 || rval == PRODUCT_HELTEC_T114 || rval == PRODUCT_OPENCOM_XL || rval == PRODUCT_TECHO || rval == PRODUCT_HMBRW) {
+	if (rval == PRODUCT_RNODE || rval == PRODUCT_RAK4631 || rval == PRODUCT_HELTEC_T114 || rval == PRODUCT_OPENCOM_XL || rval == PRODUCT_TECHO || rval == PRODUCT_HMBRW || rval == PRODUCT_DEEPLAB) {
 	#else
 	if (false) {
 	#endif
@@ -1567,6 +1576,10 @@ bool eeprom_model_valid() {
     if (model == MODEL_C8) {
     #elif BOARD_MODEL == BOARD_HELTEC_T114
     if (model == MODEL_C6 || model == MODEL_C7) {
+    #elif BOARD_MODEL == BOARD_MINIMESH_LITE
+    if (model == MODEL_52 || model == MODEL_62) {
+    #elif BOARD_MODEL == BOARD_MICROMESH
+    if (model == MODEL_53 || model == MODEL_64) {
     #elif BOARD_MODEL == BOARD_RAK4631
     if (model == MODEL_11 || model == MODEL_12 || model == MODEL_13 || model == MODEL_14) {
     #elif BOARD_MODEL == BOARD_OPENCOM_XL


### PR DESCRIPTION
Hi,

This PR adds hardware support for the new custom LoRa boards: MiniMesh Lite & MicroMesh  (NRF52). 

Key additions:
- Added board definitions and pinouts for MiniMesh Lite & MicroMesh.
- Configured SH1106 OLED support.
- Corrected EEPROM validation parameters for the new hardware.

As per the repository guidelines, this branch was created against the `master` branch for stability, which is why there might be merge conflicts with the current state of the `dev` branch. 

Please let me know if you need me to adjust anything on my end or if you prefer to handle the conflict resolution during the merge into `dev`.

Thanks!