### PR TITLE
Apply SX1262 errata 15.1 and 15.4, and enable the TCXO before calibrating

### DIFF
--- a/Radio.cpp
+++ b/Radio.cpp
@@ -292,6 +292,13 @@ void sx126x::setModulationParams(uint8_t sf, uint8_t bw, uint8_t cr, int ldro) {
   buf[7] = 0x00;
 
   executeOpcode(OP_MODULATION_PARAMS_6X, buf, 8);
+
+  // SX1262 errata 15.1: SetModulationParams resets register 0x0889, so the
+  // workaround has to be re-applied after every call, not only from
+  // setSignalBandwidth(). CMD_SF and CMD_CR reach this while the radio is
+  // running, so without this the bit is silently lost on any spreading-factor
+  // or coding-rate change made by the host.
+  optimizeModemSensitivity();
 }
 
 void sx126x::setPacketParams(uint32_t preamble, uint8_t headermode, uint8_t length, uint8_t crc) {
@@ -312,6 +319,18 @@ void sx126x::setPacketParams(uint32_t preamble, uint8_t headermode, uint8_t leng
   buf[8] = 0x00; 
 
   executeOpcode(OP_PACKET_PARAMS_6X, buf, 9);
+
+  // SX1262 errata 15.4 (Optimizing the Inverted IQ Operation): SetPacketParams
+  // resets bit 2 of register 0x0736 to the wrong value. For standard IQ - what
+  // buf[5] = 0x00 above selects - the bit must be SET after every call; for
+  // inverted IQ it must be cleared. Left unapplied, receive can fail while
+  // transmit keeps working, which is the hardest way round to diagnose.
+  uint8_t iq_reg = readRegister(0x0736);
+  if (buf[5] == 0x00) {
+    writeRegister(0x0736, iq_reg | 0x04);
+  } else {
+    writeRegister(0x0736, iq_reg & ~0x04);
+  }
 }
 
 void sx126x::reset(void) {
@@ -365,10 +384,16 @@ int sx126x::begin()
 
   if (_rxen != -1) { pinMode(_rxen, OUTPUT); }
 
+  // The TCXO has to be powered and settled BEFORE calibration, not after it.
+  // On a board with a TCXO, DIO3 supplies it, and calibrating first trims the
+  // radio against whatever reference is running at that moment - leaving a
+  // frequency offset that is never reported as an error and shows up only as
+  // reduced range. Boards without a TCXO are unaffected: enableTCXO() returns
+  // immediately when _tcxo is false.
+  enableTCXO();
+
   calibrate();
   calibrate_image(_frequency);
-
-  enableTCXO();
 
   loraMode();
   standby();
@@ -828,7 +853,19 @@ void sx126x::handleLowDataRate(){
 }
 
 void sx126x::optimizeModemSensitivity(){
-    // todo: check if there's anything the sx1262 can do here
+  // SX1262 errata 15.1, "Modulation Quality with 500 kHz LoRa Bandwidth".
+  // Bit 2 of register 0x0889 must be CLEARED when transmitting at 500 kHz
+  // bandwidth and SET at every other bandwidth. The datasheet describes the
+  // consequence as degraded modulation quality on the transmitted signal.
+  //
+  // This is a TX-side fix despite the function's name, which was inherited
+  // from the sx127x member it sits beside.
+  uint8_t reg = readRegister(0x0889);
+  if (getSignalBandwidth() == 500E3) {
+    writeRegister(0x0889, reg & 0xFB);   // clear bit 2
+  } else {
+    writeRegister(0x0889, reg | 0x04);   // set bit 2
+  }
 }
 
 void sx126x::setSignalBandwidth(uint32_t sbw)


### PR DESCRIPTION
Three SX1262 issues, all in `Radio.cpp`, all affecting every board with that modem. Happy to split this into separate PRs if you would prefer them reviewed apart — they are independent.

### 1. Errata 15.1 is never applied

`sx126x::optimizeModemSensitivity()` is an empty stub (`// todo: check if there's anything the sx1262 can do here`), so the workaround is not applied on any SX1262 board. Errata 15.1 ("Modulation Quality with 500 kHz LoRa Bandwidth") requires bit 2 of register `0x0889` to be **cleared** at 500 kHz bandwidth and **set** at every other bandwidth. Implemented here.

The function name says *sensitivity* because it sits beside the `sx127x` member of the same name, but this particular erratum is a TX-side fix — worth knowing when reading the call sites.

### 2. …and the register is reset behind it

`SetModulationParams` resets `0x0889`, so the workaround has to be re-applied after every call rather than once at setup. This matters at runtime, not just during init: the host's `CMD_SF` and `CMD_CR` handlers reach `setModulationParams()` while the radio is running, so without this the bit is silently lost whenever a host changes spreading factor or coding rate.

### 3. Errata 15.4 (inverted IQ)

`SetPacketParams` resets bit 2 of register `0x0736` to an incorrect value. For the standard, non-inverted IQ this firmware selects (`buf[5] = 0x00`), that bit must be set after each call. Left unapplied, receive can degrade while transmit continues working normally — the harder way round to diagnose.

### 4. TCXO enabled after calibration

`begin()` called `calibrate()` before `enableTCXO()`. On a board with a TCXO, DIO3 supplies it, so calibrating first trims the radio against whatever reference is running at that moment, leaving a frequency offset that is never reported as an error and shows up only as reduced range. Boards without a TCXO are unaffected — `enableTCXO()` returns immediately when `_tcxo` is false.

### Testing

Built clean against this branch:

| target | result |
|---|---|
| `firmware-heltec_t114` | 251400 bytes |
| `firmware-rak4631` | 222292 bytes |

`firmware-t3s3` does **not** build — but it fails identically on an unmodified `master` checkout (`'interfaces' was not declared in this scope` in `Radio.hpp:236`, `src/misc/ModemISR.h:6` and `Utilities.h:926`), so it is pre-existing and unrelated to this change. Happy to open a separate issue for it.

Found while bringing up a Heltec MeshPocket (nRF52840 + SX1262) as an RNode, where the TCXO ordering in particular was costing real range. The radio has been running on 915.125 MHz / 125 kHz / SF9 / CR5 with these changes and reaches a node two hops away.