### PR TITLE
nRF52: take the application size from the linker, not IMG_SIZE_START

### DIFF
--- a/Device.h
+++ b/Device.h
@@ -143,11 +143,26 @@ void device_save_firmware_hash() {
 }
 
 #if MCU_VARIANT == MCU_NRF52
+// Supplied by the nRF52 linker script. __etext is the end of .text in flash,
+// and the initialised .data image is stored immediately after it, so the
+// application occupies [APPLICATION_START, __etext + sizeof(.data)).
+//
+// This replaces a read of IMG_SIZE_START (0xFF008), which is not populated by
+// serial DFU, by UF2 drag-and-drop, or by arduino-cli upload - so the region
+// being hashed was wrong, fw_signature_validated stayed false on a correctly
+// flashed board, hw_ready was never set, and the radio silently never started.
+//
+// Taking the value from the linker means it is baked into the image at compile
+// time by the same toolchain that produced the binary: it needs no flashing
+// tool to write it, no protocol command to carry it, and nowhere to store it,
+// so it is correct however the board was flashed.
+extern uint32_t __etext;
+extern uint32_t __data_start__;
+extern uint32_t __data_end__;
+
 uint32_t retrieve_application_size() {
-    uint8_t bytes[4];
-    memcpy(bytes, (const void*)IMG_SIZE_START, 4);
-    uint32_t fw_len = bytes[0] | bytes[1] << 8 | bytes[2] << 16 | bytes[3] << 24;
-    return fw_len;
+    uint32_t data_len = (uint32_t)&__data_end__ - (uint32_t)&__data_start__;
+    return ((uint32_t)&__etext + data_len) - APPLICATION_START;
 }
 
 void calculate_region_hash(unsigned long long start, unsigned long long end, uint8_t* return_hash) {


### PR DESCRIPTION
Opening this separately at @SP5MI's suggestion in #115. It is the linker-symbol half of that discussion, standing alone so it can be reviewed on its own and reused by any future nRF52 board.

Full credit to @SP5MI for the diagnosis — [#115](https://github.com/liberatedsystems/RNode_Firmware_CE/pull/115) found and documented this, and @jacobeva's earlier `nrf52-hash-fix` branch reached the same root cause before either of us.

### The problem (as #115 describes it)

`retrieve_application_size()` reads the application size from `IMG_SIZE_START` (`0xFF008`), which is not populated by serial DFU, by UF2 drag-and-drop, or by `arduino-cli upload`. `calculate_region_hash()` therefore hashes the wrong region, `fw_signature_validated` stays false on a correctly flashed board, `hw_ready` is never set, and the radio silently never starts.

### This change

```c
extern uint32_t __etext;
extern uint32_t __data_start__;
extern uint32_t __data_end__;

uint32_t retrieve_application_size() {
    uint32_t data_len = (uint32_t)&__data_end__ - (uint32_t)&__data_start__;
    return ((uint32_t)&__etext + data_len) - APPLICATION_START;
}
```

`__etext` is the end of `.text` in flash and the initialised `.data` image is stored directly after it, so the application occupies `[APPLICATION_START, __etext + sizeof(.data))`.

The value is baked into the image at compile time by the same toolchain that produced the binary, so nothing has to write it after flashing, no command has to carry it, and there is nowhere for it to be lost. It is correct however the board was flashed — a plain UF2 drag-and-drop still validates.

### It complements #115 rather than replacing it

This derives only the **end** of the application. The other half of what #115 found — that `APPLICATION_START` varies by bootloader (`0x27000` on the XIAO with OTAFIX) — is untouched here and still needed. #115's `#ifndef` establishes the start; this establishes the end.

### Verification

Computed size compared against the actual application binary in the built DFU package:

| board | computed | actual `.bin` |
|---|---|---|
| Heltec T114 | 251456 | 251456 |
| RAK4631 | 222396 | 222396 |

Plus a third nRF52 board over five consecutive flashes, where the device-computed hash (`rnodeconf -L`) matched `sha256sum` of the flashed `.bin` exactly each time.

Those builds were done against `master`, not this base — because **`dev` currently cannot build at all.** It carries five unresolved merge conflict markers, which look like a merge committed without resolution:

```
Makefile:187     <<<<<<< HEAD  /  191 =======  /  195 >>>>>>> upstream/master
Utilities.h:1328 <<<<<<< HEAD  / 1334 =======  / 1432 >>>>>>> upstream/master
Utilities.h:1663, 1721, 1987   (same pattern)
```

`make firmware-heltec_t114` on a pristine `dev` clone stops at `Makefile:187: *** missing separator`. That is unrelated to this change — `Device.h` is byte-identical on `master` and `dev`, so this patch applies to either — but it did prevent me from building this exact base, and it presumably blocks anyone else working from `dev`. Happy to raise it separately if that is more useful.